### PR TITLE
fix: add canonical-key URL dedup and per-domain cap for browser history

### DIFF
--- a/src/collect/browser.ts
+++ b/src/collect/browser.ts
@@ -10,6 +10,7 @@ import {
 	SEARCH_ENGINES,
 	EXCLUDE_DOMAINS,
 } from "../types";
+import { deduplicateVisits, DEDUP_DEFAULTS } from "../filter/dedup";
 
 function tmpPath(suffix: string): string {
 	return join(tmpdir(), `daily-digest-${Date.now()}-${Math.random().toString(36).slice(2)}${suffix}`);
@@ -302,8 +303,16 @@ export async function collectBrowserHistory(
 	const visitLimit = VISIT_CEILING;
 	const searchLimit = SEARCH_CEILING;
 
+	const { visits: dedupedVisits } = deduplicateVisits(
+		clean.slice(0, visitLimit),
+		{
+			maxVisitsPerDomain: settings.maxVisitsPerDomain ?? DEDUP_DEFAULTS.maxVisitsPerDomain,
+			maxOtherTotal: DEDUP_DEFAULTS.maxOtherTotal,
+		}
+	);
+
 	return {
-		visits: clean.slice(0, visitLimit),
+		visits: dedupedVisits,
 		searches: searches.slice(0, searchLimit),
 	};
 }

--- a/src/filter/dedup.ts
+++ b/src/filter/dedup.ts
@@ -1,0 +1,149 @@
+import type { BrowserVisit } from "../types";
+
+export interface DedupConfig {
+	/** Max unique pages kept per domain after canonical-key grouping. Default: 5 */
+	maxVisitsPerDomain: number;
+	/** Max total entries rendered for the "Other" category. Default: 20 */
+	maxOtherTotal: number;
+}
+
+export const DEDUP_DEFAULTS: DedupConfig = {
+	maxVisitsPerDomain: 5,
+	maxOtherTotal: 20,
+};
+
+/**
+ * For Google Maps directions/place URLs, strip the `/@lat,lng,zoomz` viewport
+ * suffix that Chrome records on every zoom or pan event.
+ *
+ * Input:  /maps/dir/Providence+Canyon/Columbus+GA/@32.4527517,-84.9942759,12.67z
+ * Output: /maps/dir/Providence+Canyon/Columbus+GA
+ */
+function normalizeMapsPath(pathname: string): string {
+	const idx = pathname.indexOf("/@");
+	return idx !== -1 ? pathname.slice(0, idx) : pathname;
+}
+
+/**
+ * Compute a canonical key for a browser visit URL.
+ *
+ * Two URLs with the same canonical key are near-duplicates of the same page.
+ * The key format is: `https://<host-without-www><normalized-path>`
+ *
+ * What is stripped:
+ * - The entire query string
+ * - The URL fragment (#...)
+ * - Trailing slashes (treat /foo/ and /foo as equal)
+ * - `www.` prefix on hostname
+ * - For Google Maps: `/@lat,lng,zoom` viewport coordinate suffix in the path
+ *
+ * What is kept:
+ * - The hostname (domain identity)
+ * - The path (page identity)
+ */
+export function canonicalKey(rawUrl: string): string {
+	try {
+		const url = new URL(rawUrl);
+		const host = url.hostname.replace(/^www\./, "");
+		const isMaps =
+			(host === "maps.google.com" || host === "google.com") &&
+			url.pathname.startsWith("/maps/");
+		const path = isMaps
+			? normalizeMapsPath(url.pathname)
+			: url.pathname.replace(/\/+$/, "") || "/";
+		return `https://${host}${path}`;
+	} catch {
+		return rawUrl;
+	}
+}
+
+/**
+ * Select the most informative representative from a group of near-duplicate visits.
+ *
+ * Priority:
+ * 1. Longest title (proxy for most informative page load — e.g. page with title
+ *    vs. blank redirect vs. loading placeholder)
+ * 2. Tiebreak: earliest timestamp (first clean load, not a reload)
+ */
+function pickBest(group: BrowserVisit[]): BrowserVisit {
+	return group.reduce((best, v) => {
+		const bl = (best.title || "").length;
+		const vl = (v.title || "").length;
+		if (vl > bl) return v;
+		if (vl === bl) {
+			const bt = best.time?.getTime() ?? Infinity;
+			const vt = v.time?.getTime() ?? Infinity;
+			return vt < bt ? v : best;
+		}
+		return best;
+	});
+}
+
+export interface DedupResult {
+	visits: BrowserVisit[];
+	/** Total number of visits removed (near-duplicate collapse + per-domain cap) */
+	collapsedCount: number;
+}
+
+/**
+ * Deduplicate a list of browser visits in two phases:
+ *
+ * Phase 1 — Canonical-key grouping:
+ *   Group visits by canonical URL (strip query string, fragment, trailing slash,
+ *   www. prefix; normalise Google Maps path). Keep one representative per group
+ *   (longest title, tiebreak: earliest timestamp).
+ *
+ * Phase 2 — Per-domain cap:
+ *   After grouping, limit each domain to `config.maxVisitsPerDomain` entries
+ *   (most recent first). This prevents a legitimately-browsed domain from
+ *   dominating the note.
+ *
+ * Output is sorted by time descending (most recent first).
+ */
+export function deduplicateVisits(
+	visits: BrowserVisit[],
+	config: DedupConfig = DEDUP_DEFAULTS
+): DedupResult {
+	// Phase 1: canonical-key grouping
+	const groups = new Map<string, BrowserVisit[]>();
+	for (const v of visits) {
+		const key = canonicalKey(v.url);
+		const g = groups.get(key);
+		if (g) {
+			g.push(v);
+		} else {
+			groups.set(key, [v]);
+		}
+	}
+
+	let collapsedCount = 0;
+	const deduplicated: BrowserVisit[] = [];
+	for (const g of groups.values()) {
+		deduplicated.push(pickBest(g));
+		collapsedCount += g.length - 1;
+	}
+
+	// Phase 2: per-domain cap
+	const byDomain = new Map<string, BrowserVisit[]>();
+	for (const v of deduplicated) {
+		try {
+			const domain = new URL(v.url).hostname.replace(/^www\./, "");
+			const bucket = byDomain.get(domain) ?? [];
+			bucket.push(v);
+			byDomain.set(domain, bucket);
+		} catch {
+			// skip invalid URLs — they were already through Phase 1 so this is unlikely
+		}
+	}
+
+	const capped: BrowserVisit[] = [];
+	for (const domainVisits of byDomain.values()) {
+		domainVisits.sort((a, b) => (b.time?.getTime() ?? 0) - (a.time?.getTime() ?? 0));
+		const kept = domainVisits.slice(0, config.maxVisitsPerDomain);
+		collapsedCount += domainVisits.length - kept.length;
+		capped.push(...kept);
+	}
+
+	capped.sort((a, b) => (b.time?.getTime() ?? 0) - (a.time?.getTime() ?? 0));
+	return { visits: capped, collapsedCount };
+}

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -46,6 +46,8 @@ export interface DailyDigestSettings {
 	patternCooccurrenceWindow: number;
 	patternMinClusterSize: number;
 	trackRecurrence: boolean;
+	/** Max unique pages shown per domain in the daily note. Default: 5. Range: 1-20. */
+	maxVisitsPerDomain: number;
 	promptsDir: string;
 	hasCompletedOnboarding: boolean;
 	privacyConsentVersion: number;
@@ -91,6 +93,7 @@ export const DEFAULT_SETTINGS: DailyDigestSettings = {
 	patternCooccurrenceWindow: 30,
 	patternMinClusterSize: 3,
 	trackRecurrence: true,
+	maxVisitsPerDomain: 5,
 	promptsDir: "",
 	hasCompletedOnboarding: false,
 	privacyConsentVersion: 0,

--- a/tests/unit/filter/dedup.test.ts
+++ b/tests/unit/filter/dedup.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { canonicalKey, deduplicateVisits, DEDUP_DEFAULTS } from "../../../src/filter/dedup";
+import type { BrowserVisit } from "../../../src/types";
+
+// ── Helpers ──────────────────────────────────────────────
+
+function visit(url: string, title: string, time: Date, visitCount?: number): BrowserVisit {
+	return { url, title, time, visitCount };
+}
+
+// ── canonicalKey() ───────────────────────────────────────
+
+describe("canonicalKey", () => {
+	it("strips query string from Amazon product URL", () => {
+		const url = "https://www.amazon.com/gp/buy/thankyou/handlers/display.html?orderId=112-345&token=abc&purchaseId=xyz";
+		expect(canonicalKey(url)).toBe("https://amazon.com/gp/buy/thankyou/handlers/display.html");
+	});
+
+	it("strips /@lat,lng,zoom from Google Maps directions URL", () => {
+		const url = "https://maps.google.com/maps/dir/Providence+Canyon/Columbus+GA/@32.4527517,-84.9942759,12.67z";
+		expect(canonicalKey(url)).toBe("https://maps.google.com/maps/dir/Providence+Canyon/Columbus+GA");
+	});
+
+	it("strips www. from hostname", () => {
+		const url = "https://www.airbnb.com/book/stays/12345?locale=en&adults=2&currency=USD";
+		expect(canonicalKey(url)).toBe("https://airbnb.com/book/stays/12345");
+	});
+
+	it("returns / for root URLs with no path", () => {
+		expect(canonicalKey("https://example.com/")).toBe("https://example.com/");
+		expect(canonicalKey("https://example.com")).toBe("https://example.com/");
+	});
+
+	it("returns raw URL unchanged if new URL() throws", () => {
+		const bad = "not-a-valid-url";
+		expect(canonicalKey(bad)).toBe(bad);
+	});
+
+	it("does not strip path for non-Maps Google URLs", () => {
+		const url = "https://www.google.com/search?q=typescript+generics";
+		expect(canonicalKey(url)).toBe("https://google.com/search");
+	});
+
+	it("strips query string from Airbnb booking URL", () => {
+		const url = "https://www.airbnb.com/book/stays/99999?locale=en&adults=2&currency=USD&source=pdp_availability";
+		expect(canonicalKey(url)).toBe("https://airbnb.com/book/stays/99999");
+	});
+
+	it("strips URL fragment", () => {
+		const url = "https://docs.example.com/guide#section-3";
+		expect(canonicalKey(url)).toBe("https://docs.example.com/guide");
+	});
+
+	it("strips trailing slash from path", () => {
+		const url = "https://example.com/foo/bar/";
+		expect(canonicalKey(url)).toBe("https://example.com/foo/bar");
+	});
+
+	it("handles Google Maps via google.com/maps/ path", () => {
+		const url = "https://www.google.com/maps/place/Eiffel+Tower/@48.8583701,2.2944813,17z";
+		expect(canonicalKey(url)).toBe("https://google.com/maps/place/Eiffel+Tower");
+	});
+});
+
+// ── deduplicateVisits() — near-duplicate collapsing ──────
+
+describe("deduplicateVisits — near-duplicate collapsing", () => {
+	it("collapses 81 Google Maps zoom variants to 1, collapsedCount = 80", () => {
+		const base = "https://maps.google.com/maps/dir/Providence+Canyon/Columbus+GA";
+		const zooms = Array.from({ length: 81 }, (_, i) =>
+			visit(
+				`${base}/@32.4527517,-84.994${i},${(10 + i * 0.1).toFixed(2)}z`,
+				"Providence Canyon to Columbus, GA",
+				new Date(2026, 1, 26, 8, i)
+			)
+		);
+
+		const result = deduplicateVisits(zooms, DEDUP_DEFAULTS);
+		expect(result.visits.length).toBe(1);
+		expect(result.collapsedCount).toBe(80);
+	});
+
+	it("collapses 18 Airbnb param variants to 1", () => {
+		const base = "https://www.airbnb.com/book/stays/12345";
+		const locales = ["en", "fr", "de", "es", "it", "pt", "nl", "ja", "ko", "zh", "sv", "no", "da", "fi", "pl", "ru", "ar", "he"];
+		const visits = locales.map((locale, i) =>
+			visit(
+				`${base}?locale=${locale}&adults=2&currency=USD&source=pdp`,
+				"Airbnb booking confirmation",
+				new Date(2026, 1, 26, 10, i)
+			)
+		);
+
+		const result = deduplicateVisits(visits, DEDUP_DEFAULTS);
+		expect(result.visits.length).toBe(1);
+	});
+
+	it("collapses duplicate keys but preserves distinct paths", () => {
+		const v1 = visit("https://github.com/org/repo-a", "repo-a", new Date(2026, 1, 26, 9, 0));
+		const v2 = visit("https://github.com/org/repo-a?tab=issues", "repo-a issues", new Date(2026, 1, 26, 9, 1));
+		const v3 = visit("https://github.com/org/repo-b", "repo-b", new Date(2026, 1, 26, 9, 2));
+
+		const result = deduplicateVisits([v1, v2, v3], { maxVisitsPerDomain: 10, maxOtherTotal: 20 });
+		// repo-a and repo-a?tab=issues share canonical key; repo-b is distinct
+		expect(result.visits.length).toBe(2);
+		expect(result.collapsedCount).toBe(1);
+	});
+});
+
+// ── deduplicateVisits() — representative selection ───────
+
+describe("deduplicateVisits — representative selection", () => {
+	it("picks the visit with the longest title within a group", () => {
+		const short = visit("https://example.com/page?q=1", "Page", new Date(2026, 1, 26, 8, 0));
+		const long  = visit("https://example.com/page?q=2", "Page Title — The Full Article Headline", new Date(2026, 1, 26, 8, 1));
+		const mid   = visit("https://example.com/page?q=3", "Page Title", new Date(2026, 1, 26, 8, 2));
+
+		const result = deduplicateVisits([short, long, mid], { maxVisitsPerDomain: 10, maxOtherTotal: 20 });
+		expect(result.visits.length).toBe(1);
+		expect(result.visits[0].title).toBe("Page Title — The Full Article Headline");
+	});
+
+	it("tiebreaks equal-length titles by earliest timestamp", () => {
+		const earlier = visit("https://example.com/page?x=1", "Same Title", new Date(2026, 1, 26, 8, 0));
+		const later   = visit("https://example.com/page?x=2", "Same Title", new Date(2026, 1, 26, 9, 0));
+
+		const result = deduplicateVisits([later, earlier], { maxVisitsPerDomain: 10, maxOtherTotal: 20 });
+		expect(result.visits.length).toBe(1);
+		expect(result.visits[0].time).toEqual(new Date(2026, 1, 26, 8, 0));
+	});
+});
+
+// ── deduplicateVisits() — per-domain cap ─────────────────
+
+describe("deduplicateVisits — per-domain cap", () => {
+	it("caps 10 distinct github.com paths to 5 (most recent 5)", () => {
+		const visits = Array.from({ length: 10 }, (_, i) =>
+			visit(
+				`https://github.com/org/repo-${i}`,
+				`repo-${i}`,
+				new Date(2026, 1, 26, 8, i)   // i=0 is earliest, i=9 is latest
+			)
+		);
+
+		const result = deduplicateVisits(visits, { maxVisitsPerDomain: 5, maxOtherTotal: 20 });
+		expect(result.visits.length).toBe(5);
+		// The 5 most recent should be kept (indices 5-9)
+		const titles = result.visits.map((v) => v.title);
+		for (let i = 5; i <= 9; i++) {
+			expect(titles).toContain(`repo-${i}`);
+		}
+	});
+
+	it("keeps all entries for two domains each with 3 distinct pages", () => {
+		const githubVisits = Array.from({ length: 3 }, (_, i) =>
+			visit(`https://github.com/repo-${i}`, `github repo ${i}`, new Date(2026, 1, 26, 8, i))
+		);
+		const npmVisits = Array.from({ length: 3 }, (_, i) =>
+			visit(`https://npmjs.com/package/pkg-${i}`, `npm pkg ${i}`, new Date(2026, 1, 26, 9, i))
+		);
+
+		const result = deduplicateVisits([...githubVisits, ...npmVisits], { maxVisitsPerDomain: 5, maxOtherTotal: 20 });
+		expect(result.visits.length).toBe(6);
+	});
+});
+
+// ── Output properties ────────────────────────────────────
+
+describe("deduplicateVisits — output properties", () => {
+	it("output is sorted by time descending", () => {
+		const visits = [
+			visit("https://alpha.com/a", "Alpha A", new Date(2026, 1, 26, 8, 0)),
+			visit("https://beta.com/b",  "Beta B",  new Date(2026, 1, 26, 10, 0)),
+			visit("https://gamma.com/c", "Gamma C", new Date(2026, 1, 26, 9, 0)),
+		];
+
+		const result = deduplicateVisits(visits, DEDUP_DEFAULTS);
+		const times = result.visits.map((v) => v.time?.getTime() ?? 0);
+		expect(times).toEqual([...times].sort((a, b) => b - a));
+	});
+
+	it("collapsedCount equals total input length minus output length", () => {
+		// 5 Google Maps variants → 1 canonical after phase 1
+		// 4 github.com distinct → capped at 3 after phase 2
+		const mapsVisits = Array.from({ length: 5 }, (_, i) =>
+			visit(
+				`https://maps.google.com/maps/place/Paris/@48.858${i},2.294,15z`,
+				"Paris",
+				new Date(2026, 1, 26, 8, i)
+			)
+		);
+		const githubVisits = Array.from({ length: 4 }, (_, i) =>
+			visit(`https://github.com/user/proj-${i}`, `proj ${i}`, new Date(2026, 1, 26, 9, i))
+		);
+
+		const input = [...mapsVisits, ...githubVisits];
+		const result = deduplicateVisits(input, { maxVisitsPerDomain: 3, maxOtherTotal: 20 });
+
+		expect(result.collapsedCount).toBe(input.length - result.visits.length);
+	});
+
+	it("returns empty result for empty input", () => {
+		const result = deduplicateVisits([], DEDUP_DEFAULTS);
+		expect(result.visits).toEqual([]);
+		expect(result.collapsedCount).toBe(0);
+	});
+
+	it("returns single visit unchanged", () => {
+		const v = visit("https://example.com/page", "Example Page", new Date(2026, 1, 26, 8, 0));
+		const result = deduplicateVisits([v], DEDUP_DEFAULTS);
+		expect(result.visits.length).toBe(1);
+		expect(result.collapsedCount).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

- New `src/filter/dedup.ts`: canonical-key deduplication + per-domain cap
  - `canonicalKey()` strips query string, fragment, `www.` prefix, and Google Maps `/@lat,lng,zoom` viewport from path
  - `deduplicateVisits()` two-phase: (1) canonical-key grouping picks best representative (longest title, earliest tiebreak), (2) per-domain cap (default 5)
  - Reduces Google Maps zoom variants (81 → 1), Airbnb param variants (18 → 1), Amazon checkout reloads (12 → 1)
- `src/collect/browser.ts`: calls `deduplicateVisits()` before returning
- `src/settings/types.ts`: adds `maxVisitsPerDomain: number` (default 5)

## Test plan

- [x] `tests/unit/filter/dedup.test.ts` — 18 new tests: `canonicalKey()` (10 cases), `deduplicateVisits()` (8 cases)
- [x] `npm run test` — all pass
- [x] `npm run build` — clean
- [x] `npm run lint` — clean