### PR TITLE
fix: clean tracking URLs and collapse redirect wrappers for display

### DIFF
--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -12,6 +12,7 @@ import { AIProvider } from "../settings/types";
 import { KnowledgeSections } from "../analyze/knowledge";
 import { formatDetailsBlock, type PromptLog } from "../../scripts/lib/prompt-logger";
 import { escapeForMarkdown, escapeForLinkText, escapeForTableCell, escapeForYaml } from "./escape";
+import { cleanUrlForDisplay } from "./url-display";
 
 function formatTime(d: Date | null): string {
 	if (!d) return "";
@@ -330,8 +331,8 @@ export function renderMarkdown(
 					const ts = formatTime(v.time);
 					let title = (v.title || "").trim() || v.url;
 					if (title.length > 75) title = title.slice(0, 75) + "\u2026";
-					const safeUrl = v.url.replace(/\)/g, "%29");
-					lines.push(`  - [${escapeForLinkText(title)}](${safeUrl})` + (ts ? ` \u2014 ${ts}` : ""));
+					const displayUrl = cleanUrlForDisplay(v.url).replace(/\)/g, "%29");
+					lines.push(`  - [${escapeForLinkText(title)}](${displayUrl})` + (ts ? ` \u2014 ${ts}` : ""));
 				}
 			}
 			lines.push("");

--- a/src/render/url-display.ts
+++ b/src/render/url-display.ts
@@ -1,0 +1,160 @@
+/**
+ * url-display.ts
+ *
+ * Display-only URL cleanup for the renderer. Called at render time only.
+ * Never modifies BrowserVisit.url — the original URL is preserved in memory,
+ * in AI prompts, and in any debug output.
+ *
+ * Two-layer approach:
+ *   Layer 1: Strip known tracking/noise query parameters
+ *   Layer 2: Collapse known redirect/wrapper domains to a readable label
+ *   Fallback: Truncate at 120 chars at a segment boundary
+ */
+
+const MAX_DISPLAY_LENGTH = 120;
+
+const DISPLAY_STRIP_PARAMS = new Set([
+	// Universal campaign/ad-click
+	"utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+	"utm_name", "utm_cid", "utm_reader",
+
+	// Platform click IDs
+	"gclid", "gclsrc",            // Google Ads / DoubleClick
+	"gbraid", "wbraid",           // Google Ads (iOS14+ privacy-preserving)
+	"fbclid", "igshid",           // Facebook / Instagram
+	"msclkid",                    // Microsoft Advertising / Bing
+	"twclid",                     // Twitter / X
+	"ttclid",                     // TikTok Ads
+	"li_fat_id",                  // LinkedIn
+	"epik",                       // Pinterest
+	"scid",                       // Snapchat
+	"yclid",                      // Yandex
+
+	// HubSpot
+	"_hsenc", "_hsmi",
+
+	// Mailchimp
+	"mc_cid", "mc_eid",
+
+	// Marketo
+	"mkt_tok",
+
+	// Vero
+	"vero_conv", "vero_id",
+
+	// LinkedIn email-specific
+	"trk", "trkemail", "trackingid", "refid", "lipi",
+	"midtoken", "midsig", "eid", "otptoken",
+
+	// Matomo / Piwik
+	"pk_campaign", "pk_kwd", "pk_source", "pk_medium", "pk_content",
+
+	// Adobe Analytics
+	"icid", "ICID",
+
+	// Miscellaneous click tracking
+	"ncid", "nr_email_referer",
+	"si",               // YouTube/Spotify share session
+	"feature",          // YouTube feature tracking
+
+	// Google search internal (no semantic content)
+	"ved", "ei", "uact", "sxsrf", "rlz",
+
+	// Amazon product/session noise
+	"qid", "srs", "camp", "creative", "linkCode", "tag",
+	"linkId", "ascsubtag",
+
+	// ShareThis / social
+	"sr_share",
+]);
+
+const TRACKING_WRAPPER_DOMAINS: { pattern: RegExp; label: string }[] = [
+	// HubSpot
+	{ pattern: /\.hubspotlinks\.com$/, label: "HubSpot tracking link" },
+	{ pattern: /\.hs-email\.net$/, label: "HubSpot tracking link" },
+	{ pattern: /\.sidekickopen\d*\.com$/, label: "HubSpot tracking link" },
+	{ pattern: /\.na\d+\.hs-sales-engage\.com$/, label: "HubSpot tracking link" },
+	// Microsoft ATP Safe Links
+	{ pattern: /safelinks\.protection\.outlook\.com$/, label: "Outlook SafeLink" },
+	// Proofpoint
+	{ pattern: /urldefense\.proofpoint\.com$/, label: "Proofpoint link" },
+	{ pattern: /urldefense\.com$/, label: "Proofpoint link" },
+	// Mimecast
+	{ pattern: /url\d*\.mimecastprotect\.com$/, label: "Mimecast link" },
+	// SendGrid
+	{ pattern: /\.sendgrid\.net$/, label: "SendGrid tracking link" },
+	// Mailchimp / Mandrill
+	{ pattern: /click\.mailchimp\.com$/, label: "Mailchimp tracking link" },
+	{ pattern: /mandrillapp\.com$/, label: "Mandrill tracking link" },
+	// Marketo
+	{ pattern: /click\.marketo\.com$/, label: "Marketo tracking link" },
+	// Constant Contact
+	{ pattern: /tracking\.constantcontact\.com$/, label: "Constant Contact link" },
+	// ConvertKit
+	{ pattern: /click\.convertkit-mail\.com$/, label: "ConvertKit link" },
+	// Generic shorteners
+	{ pattern: /^t\.co$/, label: "Twitter/X short link" },
+	{ pattern: /^bit\.ly$/, label: "bit.ly short link" },
+	{ pattern: /^ow\.ly$/, label: "Hootsuite short link" },
+	{ pattern: /^buff\.ly$/, label: "Buffer short link" },
+	{ pattern: /^tinyurl\.com$/, label: "TinyURL link" },
+];
+
+/**
+ * Returns a cleaned, human-readable version of `url` for display in Markdown
+ * links. The original URL is never modified — this is called only at render time.
+ *
+ * @param url - The URL string to clean (may be raw or already sanitized)
+ * @returns A shortened, de-tracked display string
+ */
+export function cleanUrlForDisplay(url: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		// Not a valid URL — apply truncation only
+		return url.length > MAX_DISPLAY_LENGTH
+			? url.slice(0, MAX_DISPLAY_LENGTH) + "\u2026"
+			: url;
+	}
+
+	const hostname = parsed.hostname.toLowerCase();
+
+	// Layer 2: collapse known redirect/wrapper domains before stripping params —
+	// the destination URL is encoded in the path/query and is not recoverable
+	// without an HTTP fetch, so collapse to a labeled placeholder.
+	for (const { pattern, label } of TRACKING_WRAPPER_DOMAINS) {
+		if (pattern.test(hostname)) {
+			return `${hostname} [${label}]`;
+		}
+	}
+
+	// Layer 1: strip known tracking/noise query parameters
+	const keysToDelete: string[] = [];
+	for (const key of parsed.searchParams.keys()) {
+		if (DISPLAY_STRIP_PARAMS.has(key) || DISPLAY_STRIP_PARAMS.has(key.toLowerCase())) {
+			keysToDelete.push(key);
+		}
+	}
+	for (const key of keysToDelete) {
+		parsed.searchParams.delete(key);
+	}
+
+	let clean = parsed.toString();
+
+	// Truncation fallback: break at a segment boundary (?, &, or /) if possible
+	if (clean.length > MAX_DISPLAY_LENGTH) {
+		const breakPoints = ["?", "&", "/"];
+		let cut = MAX_DISPLAY_LENGTH;
+		for (const bp of breakPoints) {
+			const idx = clean.lastIndexOf(bp, MAX_DISPLAY_LENGTH);
+			if (idx > 30) {
+				cut = idx;
+				break;
+			}
+		}
+		clean = clean.slice(0, cut) + "\u2026";
+	}
+
+	return clean;
+}

--- a/tests/unit/render/url-display.test.ts
+++ b/tests/unit/render/url-display.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { cleanUrlForDisplay } from "../../../src/render/url-display";
+
+describe("cleanUrlForDisplay", () => {
+	// Test 1: HubSpot tracking URL → collapses to labeled placeholder
+	it("collapses HubSpot tracking URLs to a label", () => {
+		const url = "https://d2v8tf04.na1.hubspotlinks.com/events/public/v1/encoded/track/eyJhbGciOiJIUzI1NiJ9.example";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toBe("d2v8tf04.na1.hubspotlinks.com [HubSpot tracking link]");
+	});
+
+	// Test 2: Adobe unsubscribe with long base64 ?p= param → truncated
+	it("truncates Adobe unsubscribe URL with long base64 param", () => {
+		const url = "https://www.adobe.com/unsubscribe.html?p=iTlazJBe%2FVowDgv4aiYxnpZETQsabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789==&source=newsletter";
+		const result = cleanUrlForDisplay(url);
+		expect(result.length).toBeLessThanOrEqual(121); // 120 chars + "…"
+		expect(result.endsWith("\u2026")).toBe(true);
+		expect(result).not.toContain("d2v8tf04"); // sanity — not confused with HubSpot
+	});
+
+	// Test 3: UTM params stripped, real params preserved
+	it("strips UTM params and preserves meaningful query params", () => {
+		const url = "https://example.com/article?id=42&utm_source=newsletter&utm_medium=email&utm_campaign=spring";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toContain("id=42");
+		expect(result).not.toContain("utm_source");
+		expect(result).not.toContain("utm_medium");
+		expect(result).not.toContain("utm_campaign");
+	});
+
+	// Test 4: gclid + fbclid stripped, color=red preserved
+	it("strips gclid and fbclid but preserves color param", () => {
+		const url = "https://shop.example.com/products?color=red&gclid=abc123&fbclid=xyz789";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toContain("color=red");
+		expect(result).not.toContain("gclid");
+		expect(result).not.toContain("fbclid");
+	});
+
+	// Test 5: All params are tracking-only → trailing ? removed
+	it("removes trailing ? when all params are stripped", () => {
+		const url = "https://example.com/page?utm_source=email&utm_medium=cpc&fbclid=abc";
+		const result = cleanUrlForDisplay(url);
+		expect(result).not.toMatch(/\?$/);
+		expect(result).not.toContain("utm_source");
+		// The URL constructor serializes an empty search as no trailing ?
+		expect(result).toBe("https://example.com/page");
+	});
+
+	// Test 6: Outlook SafeLink → collapses to label
+	it("collapses Outlook SafeLinks to a label", () => {
+		const url = "https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fexample.com&data=05%7C01%7C";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toBe("nam04.safelinks.protection.outlook.com [Outlook SafeLink]");
+	});
+
+	// Test 7: t.co short link → collapses to label
+	it("collapses t.co short links to a label", () => {
+		const url = "https://t.co/abc123XYZ";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toBe("t.co [Twitter/X short link]");
+	});
+
+	// Test 8: Clean URL passes through unchanged
+	it("passes clean URLs through without modification", () => {
+		const url = "https://developer.mozilla.org/en-US/docs/Web/JavaScript";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toBe(url);
+	});
+
+	// Test 9: Long Google Maps /data=!4m9 path → truncated at segment boundary
+	it("truncates long Google Maps data paths at a segment boundary", () => {
+		const url = "https://maps.google.com/maps/@32.4527517,-84.9942759,12.67z/data=!4m9!4m8!1m0!1m5!1m1!1s0x888f2d5da4b3f28d!2m2!1d-84.9942759!2d32.4527517!3e0";
+		const result = cleanUrlForDisplay(url);
+		expect(result.length).toBeLessThanOrEqual(121);
+		expect(result.endsWith("\u2026")).toBe(true);
+		// The truncation cuts at the / boundary (slice excludes the / itself),
+		// so the char just before the ellipsis is the last path segment character.
+		// Verify the result is a prefix of the original URL (minus the ellipsis).
+		const withoutEllipsis = result.slice(0, -1);
+		expect(url.startsWith(withoutEllipsis)).toBe(true);
+		// Confirm the next character in the original URL at that cut point is a /
+		expect(url[withoutEllipsis.length]).toBe("/");
+	});
+
+	// Test 10: Invalid URL → no throw, fallback truncation
+	it("does not throw on invalid URLs and applies fallback truncation", () => {
+		const notAUrl = "not a url at all :: garbage :: " + "x".repeat(100);
+		expect(() => cleanUrlForDisplay(notAUrl)).not.toThrow();
+		const result = cleanUrlForDisplay(notAUrl);
+		expect(result.endsWith("\u2026")).toBe(true);
+		expect(result.length).toBeLessThanOrEqual(121);
+	});
+
+	// Test 11: mkt_tok (Marketo) stripped, id=123 preserved
+	it("strips mkt_tok but preserves id param", () => {
+		const url = "https://info.example.com/product?id=123&mkt_tok=ODI3LVVQSy03MzIAAAGBtoken";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toContain("id=123");
+		expect(result).not.toContain("mkt_tok");
+	});
+
+	// Test 12: Proofpoint URL Defense → collapses to label
+	it("collapses Proofpoint URL Defense links to a label", () => {
+		const url = "https://urldefense.proofpoint.com/v2/url?u=https-3A__example.com&d=DwMGaQ&c=euGZstcaTDllvimEN8b7jXrwqOf-v5A";
+		const result = cleanUrlForDisplay(url);
+		expect(result).toBe("urldefense.proofpoint.com [Proofpoint link]");
+	});
+});


### PR DESCRIPTION
## Summary

- New `src/render/url-display.ts`: `cleanUrlForDisplay(url)` — display-only cleaning that doesn't mutate `BrowserVisit.url`
  - **Layer 1**: Strips 50+ tracking/noise query params (utm_*, gclid, fbclid, msclkid, mkt_tok, _hsenc, ved, ei, etc.)
  - **Layer 2**: Collapses 20 known redirect/wrapper domains to human-readable labels (HubSpot → `[HubSpot tracking link]`, Outlook SafeLinks, Proofpoint, SendGrid, t.co, bit.ly, etc.)
  - **Fallback**: Truncates at 120 chars at a segment boundary (`?`, `&`, `/`)
- `src/render/renderer.ts`: One-line call site change — `const displayUrl = cleanUrlForDisplay(v.url).replace(...)` in browser activity loop

Architecture: `sanitize.ts` removes params at Stage 2 for privacy; `url-display.ts` cleans the same (and more) at Stage 9 for readability. Separate concerns, both intentional.

## Test plan

- [x] `tests/unit/render/url-display.test.ts` — 12 test cases (HubSpot collapse, Adobe unsubscribe truncation, UTM/gclid stripping, SafeLink collapse, t.co collapse, clean passthrough, Maps path truncation, invalid URL graceful degradation, Marketo strip)
- [x] `npm run test` — 779 passed | 45 skipped
- [x] `npm run build` — clean
- [x] `npm run lint` — clean