### PR TITLE
feat: article-first browsing with TF-IDF clustering and Today I Read About section

### DIFF
--- a/src/analyze/clusters.ts
+++ b/src/analyze/clusters.ts
@@ -1,0 +1,320 @@
+/**
+ * TF-IDF Article Clustering — Stage D of the article-first browsing pipeline.
+ *
+ * Groups substantive browser visits (engagement score >= 0.5) into thematic
+ * clusters using TF-IDF vectorisation and cosine similarity. Each cluster
+ * represents a focused reading/research session.
+ *
+ * The result is an `ArticleCluster[]` added to `KnowledgeSections` and
+ * rendered as the "Today I Read About" section in the daily note.
+ *
+ * Algorithm:
+ * 1. Filter visits to those with engagement score >= 0.5
+ * 2. Build a TF-IDF matrix over cleaned titles
+ * 3. Greedily assign each visit to an existing cluster if:
+ *    - The time gap from the last cluster visit < sessionGapMs (45 min default)
+ *    - Cosine similarity to the cluster centroid >= similarityThreshold (0.3)
+ * 4. Otherwise start a new cluster
+ * 5. Label each cluster with top-3 most frequent meaningful words
+ * 6. Infer intent from domain diversity and revisit patterns
+ * 7. Drop singleton clusters (< 2 articles) — they appear in domain view instead
+ *
+ * No LLM calls. No network. No external libraries.
+ */
+
+import { ArticleCluster, BrowserVisit } from "../types";
+import { ENTITY_STOPWORDS } from "../filter/classify";
+import { cleanTitle } from "../collect/browser";
+
+// ── TF-IDF Tokenizer ─────────────────────────────────────
+
+/**
+ * A lowercase-normalised copy of ENTITY_STOPWORDS for case-insensitive matching.
+ * ENTITY_STOPWORDS stores capitalized forms ("The", "HTML", "API"); the tokenizer
+ * works on lowercased tokens, so we need a lowercased set for the check.
+ */
+const STOPWORDS_LOWER = new Set(
+	[...ENTITY_STOPWORDS].map((w) => w.toLowerCase()),
+);
+
+/**
+ * Tokenise a cleaned article title for TF-IDF.
+ * - Lowercase
+ * - Remove punctuation
+ * - Split on whitespace
+ * - Keep tokens longer than 2 chars
+ * - Remove tokens in ENTITY_STOPWORDS (case-insensitive)
+ */
+function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.replace(/[^\w\s]/g, " ")
+		.split(/\s+/)
+		.filter((w) => w.length > 2 && !STOPWORDS_LOWER.has(w));
+}
+
+// ── TF-IDF Matrix ────────────────────────────────────────
+
+/**
+ * Build a TF-IDF matrix for a list of titles.
+ *
+ * Returns a Map keyed by document index (as string) where each value is a Map
+ * from term to TF-IDF score.
+ *
+ * TF  = term frequency within document (count / doc token count)
+ * IDF = log(N / document frequency)
+ */
+export function buildTfIdf(titles: string[]): Map<string, Map<string, number>> {
+	const termFreqs = titles.map((t) => {
+		const tokens = tokenize(t);
+		const freq = new Map<string, number>();
+		for (const tok of tokens) {
+			freq.set(tok, (freq.get(tok) ?? 0) + 1);
+		}
+		return freq;
+	});
+
+	const docFreq = new Map<string, number>();
+	for (const tf of termFreqs) {
+		for (const term of tf.keys()) {
+			docFreq.set(term, (docFreq.get(term) ?? 0) + 1);
+		}
+	}
+
+	const N = titles.length;
+	const tfidfMatrix = new Map<string, Map<string, number>>();
+	titles.forEach((_, i) => {
+		const row = new Map<string, number>();
+		const tf = termFreqs[i];
+		const docSize = tf.size || 1;
+		for (const [term, count] of tf) {
+			// Use 1 + log(N/df) (smooth IDF) to avoid IDF = 0 for terms appearing in all docs.
+			// Without smoothing, shared terms across a 2-doc corpus get IDF = log(1) = 0,
+			// making cosine similarity always 0 on small corpora.
+			const df = docFreq.get(term) ?? 1;
+			const idf = 1 + Math.log(N / df);
+			row.set(term, (count / docSize) * idf);
+		}
+		tfidfMatrix.set(String(i), row);
+	});
+
+	return tfidfMatrix;
+}
+
+// ── Cosine Similarity ────────────────────────────────────
+
+/**
+ * Compute cosine similarity between two sparse TF-IDF vectors.
+ * Returns 0 if either vector is zero-length.
+ */
+export function cosineSimilarity(
+	a: Map<string, number>,
+	b: Map<string, number>,
+): number {
+	let dot = 0;
+	let normA = 0;
+	let normB = 0;
+	for (const [k, va] of a) {
+		const vb = b.get(k) ?? 0;
+		dot += va * vb;
+		normA += va * va;
+	}
+	for (const vb of b.values()) {
+		normB += vb * vb;
+	}
+	const denom = Math.sqrt(normA) * Math.sqrt(normB);
+	return denom > 0 ? dot / denom : 0;
+}
+
+// ── Cluster Centroid ─────────────────────────────────────
+
+/**
+ * Compute the centroid (element-wise average) of a list of TF-IDF vectors.
+ * Used to compare new visits to an existing cluster's centre of mass.
+ */
+function buildCentroid(vectors: Map<string, number>[]): Map<string, number> {
+	const centroid = new Map<string, number>();
+	const n = vectors.length;
+	if (n === 0) return centroid;
+	for (const vec of vectors) {
+		for (const [term, score] of vec) {
+			centroid.set(term, (centroid.get(term) ?? 0) + score / n);
+		}
+	}
+	return centroid;
+}
+
+// ── Cluster Labelling ────────────────────────────────────
+
+/**
+ * Produce a short human-readable label for a cluster from its articles.
+ *
+ * Takes the top-3 most frequent meaningful words across all article titles
+ * (> 3 chars, not in stopwords) and joins them with a space.
+ */
+export function labelCluster(articles: string[]): string {
+	const freq = new Map<string, number>();
+	for (const a of articles) {
+		const words = a
+			.toLowerCase()
+			.split(/\s+/)
+			.filter((w) => w.length > 3 && !STOPWORDS_LOWER.has(w));
+		for (const w of words) {
+			freq.set(w, (freq.get(w) ?? 0) + 1);
+		}
+	}
+	const sorted = [...freq.entries()].sort((a, b) => b[1] - a[1]);
+	return sorted
+		.slice(0, 3)
+		.map(([w]) => w)
+		.join(" ");
+}
+
+// ── Intent Inference ─────────────────────────────────────
+
+/**
+ * Infer the intent signal for a cluster based on its visits.
+ *
+ * - "research"       — 3+ distinct domains (consulted multiple sources)
+ * - "reference"      — any URL appears more than once (kept referring back)
+ * - "implementation" — only 1–2 domains but revisit detected (building something)
+ * - "browsing"       — default: single-domain, single-pass reading
+ */
+export function inferIntent(cluster: ArticleCluster): ArticleCluster["intentSignal"] {
+	const domains = new Set(
+		cluster.visits.map((v) => {
+			try {
+				return new URL(v.url).hostname.replace(/^www\./, "");
+			} catch {
+				return "";
+			}
+		}),
+	);
+	if (domains.size >= 3) return "research";
+
+	// Revisit: same URL appears more than once
+	const urlCounts = new Map<string, number>();
+	for (const v of cluster.visits) {
+		urlCounts.set(v.url, (urlCounts.get(v.url) ?? 0) + 1);
+	}
+	const hasRevisit = [...urlCounts.values()].some((c) => c > 1);
+	if (hasRevisit) return "reference";
+
+	return "browsing";
+}
+
+// ── Main Clustering Function ─────────────────────────────
+
+/**
+ * Group substantive browser visits into thematic article clusters.
+ *
+ * Only visits with `engagementScores[i] >= 0.5` are included. Singletons
+ * (clusters with fewer than 2 articles) are dropped — they appear in the
+ * domain-grouped browser activity view instead.
+ *
+ * @param visits             - All browser visits for the day
+ * @param cleanedTitles      - `cleanTitle(v.title)` for each visit (parallel array)
+ * @param engagementScores   - `computeEngagementScore()` for each visit (parallel array)
+ * @param sessionGapMs       - Max milliseconds between visits to stay in same cluster (default: 45 min)
+ * @param similarityThreshold - Min cosine similarity to join an existing cluster (default: 0.3)
+ */
+export function clusterArticles(
+	visits: BrowserVisit[],
+	cleanedTitles: string[],
+	engagementScores: number[],
+	sessionGapMs = 45 * 60 * 1000,
+	similarityThreshold = 0.3,
+): ArticleCluster[] {
+	// Filter to substantive visits only
+	const substantive: BrowserVisit[] = [];
+	const substantiveTitles: string[] = [];
+	const substantiveScores: number[] = [];
+	for (let i = 0; i < visits.length; i++) {
+		if (engagementScores[i] >= 0.5) {
+			substantive.push(visits[i]);
+			substantiveTitles.push(cleanedTitles[i]);
+			substantiveScores.push(engagementScores[i]);
+		}
+	}
+
+	if (substantive.length === 0) return [];
+
+	// Sort by timestamp ascending for greedy left-to-right session assignment
+	const sortedIndices = substantive
+		.map((_, i) => i)
+		.sort((a, b) => (substantive[a].time?.getTime() ?? 0) - (substantive[b].time?.getTime() ?? 0));
+
+	const sortedVisits = sortedIndices.map((i) => substantive[i]);
+	const sortedTitles = sortedIndices.map((i) => substantiveTitles[i]);
+	const sortedScores = sortedIndices.map((i) => substantiveScores[i]);
+
+	const tfidf = buildTfIdf(sortedTitles);
+	const clusters: ArticleCluster[] = [];
+
+	// Track which corpus indices belong to each cluster for centroid computation
+	const clusterMemberIndices: number[][] = [];
+
+	for (let i = 0; i < sortedVisits.length; i++) {
+		const visit = sortedVisits[i];
+		const title = sortedTitles[i];
+		const score = sortedScores[i];
+		const vec = tfidf.get(String(i)) ?? new Map<string, number>();
+
+		let placed = false;
+
+		for (let ci = 0; ci < clusters.length; ci++) {
+			const cluster = clusters[ci];
+			const lastVisit = cluster.visits[cluster.visits.length - 1];
+			if (!lastVisit.time || !visit.time) continue;
+			const gap = visit.time.getTime() - lastVisit.time.getTime();
+			if (gap > sessionGapMs) continue;
+
+			// Compare to cluster centroid using the same full-corpus TF-IDF vectors
+			const memberVectors = clusterMemberIndices[ci].map(
+				(idx) => tfidf.get(String(idx)) ?? new Map<string, number>(),
+			);
+			const centroid = buildCentroid(memberVectors);
+
+			if (cosineSimilarity(vec, centroid) >= similarityThreshold) {
+				cluster.visits.push(visit);
+				cluster.articles.push(title);
+				clusterMemberIndices[ci].push(i);
+				if (visit.time) cluster.timeRange.end = visit.time;
+				// Update running average engagement score
+				cluster.engagementScore =
+					(cluster.engagementScore * (cluster.visits.length - 1) + score) /
+					cluster.visits.length;
+				placed = true;
+				break;
+			}
+		}
+
+		if (!placed) {
+			clusters.push({
+				label: "", // computed after all visits are placed
+				articles: [title],
+				visits: [visit],
+				timeRange: {
+					start: visit.time ?? new Date(),
+					end: visit.time ?? new Date(),
+				},
+				engagementScore: score,
+				intentSignal: "browsing",
+			});
+			clusterMemberIndices.push([i]);
+		}
+	}
+
+	// Label each cluster and infer intent
+	for (const cluster of clusters) {
+		cluster.label = labelCluster(cluster.articles);
+		cluster.intentSignal = inferIntent(cluster);
+	}
+
+	// Drop singleton clusters (< 2 articles)
+	return clusters.filter((c) => c.articles.length >= 2);
+}
+
+// ── Convenience re-export ─────────────────────────────────
+
+export { cleanTitle };

--- a/src/analyze/engagement.ts
+++ b/src/analyze/engagement.ts
@@ -1,0 +1,77 @@
+/**
+ * Engagement Scoring — Stage C of the article-first browsing pipeline.
+ *
+ * Assigns each browser visit a score from 0.0–1.0 representing the likelihood
+ * that it was a substantive, knowledge-seeking interaction rather than
+ * background navigation or noise.
+ *
+ * Threshold: score >= 0.5 = "substantive". Below 0.5 = background noise or
+ * purely navigational.
+ *
+ * Scoring is entirely local — no LLM calls, no network, no API keys.
+ */
+
+import { BrowserVisit } from "../types";
+import { SearchVisitPair } from "./intent";
+
+// ── Engagement Score Constants ───────────────────────────
+
+/**
+ * Titles with at least this many words contain enough semantic content to be
+ * considered meaningful (vs. single-word titles like "About" or "Contact").
+ */
+const SUBSTANTIVE_TITLE_MIN_WORDS = 5;
+
+/**
+ * Technical term patterns in a title signal debugging or implementation work:
+ * - version numbers (1.2.3, 20.0)
+ * - Error/Exception suffixes (TypeError, RangeException)
+ * - method-call patterns at word boundary (reduce(), map())
+ * - CSS class/ID selectors (#root, .foo)
+ */
+const TECHNICAL_TERMS_RE =
+	/\b\d+\.\d+\b|\b\w+Error\b|\b\w+Exception\b|\b\w+\(\)|\B#\w+|\B\.\w+\(/;
+
+// ── Engagement Scoring ───────────────────────────────────
+
+/**
+ * Compute an engagement score for a single browser visit.
+ *
+ * Score components (capped at 1.0):
+ * - +0.25 if the cleaned title has >= 5 words (content-rich title)
+ * - +0.20 if the same URL was visited more than once today (revisit signal)
+ * - +0.25 if this visit was preceded by a related search query (intent signal)
+ * - +0.15 if the cleaned title contains technical terms (debugging/implementing)
+ *
+ * @param visit        - The visit being scored
+ * @param cleanedTitle - Output of `cleanTitle(visit.title)` — empty string if noise
+ * @param todayVisits  - All visits for the day (used to count revisits)
+ * @param searchLinks  - Output of `linkSearchesToVisits()` for search-intent linkage
+ */
+export function computeEngagementScore(
+	visit: BrowserVisit,
+	cleanedTitle: string,
+	todayVisits: BrowserVisit[],
+	searchLinks: SearchVisitPair[],
+): number {
+	let score = 0;
+
+	// Title quality: enough words to encode a real topic
+	const wordCount = cleanedTitle.split(/\s+/).filter(Boolean).length;
+	if (wordCount >= SUBSTANTIVE_TITLE_MIN_WORDS) score += 0.25;
+
+	// Revisit signal: same URL loaded more than once today = implementing or referring back
+	const todayRevisitCount = todayVisits.filter((v) => v.url === visit.url).length;
+	if (todayRevisitCount > 1) score += 0.20;
+
+	// Search-intent linkage: visit was preceded by a related search query
+	const linkedToSearch = searchLinks.some((sl) =>
+		sl.visits.some((v) => v.url === visit.url)
+	);
+	if (linkedToSearch) score += 0.25;
+
+	// Technical terms in title: debugging/implementing signal
+	if (TECHNICAL_TERMS_RE.test(cleanedTitle)) score += 0.15;
+
+	return Math.min(score, 1.0);
+}

--- a/src/analyze/intent.ts
+++ b/src/analyze/intent.ts
@@ -1,0 +1,71 @@
+/**
+ * Search-Visit Linkage — Stage B of the article-first browsing pipeline.
+ *
+ * Pairs search queries with the page visits that followed within a configurable
+ * time window. This linkage identifies informational intent: a search followed
+ * by page visits is evidence that the user was actively seeking knowledge, not
+ * just navigating to a known destination.
+ *
+ * No LLM calls. No network. No API keys. Offline-only.
+ */
+
+import { BrowserVisit, SearchQuery } from "../types";
+
+// ── Search-Visit Pair ────────────────────────────────────
+
+/**
+ * A search query paired with the browser visits that occurred shortly after it.
+ *
+ * `intentType`:
+ * - "directed"   — 1–2 result pages visited; user found what they wanted quickly
+ * - "undirected" — 3+ result pages visited; user was exploring or comparing sources
+ */
+export interface SearchVisitPair {
+	query: string;
+	visits: BrowserVisit[];
+	intentType: "directed" | "undirected";
+}
+
+// ── Search-Visit Linkage ─────────────────────────────────
+
+/**
+ * Link each search query to the page visits that occurred within `windowMs`
+ * milliseconds after the search was issued.
+ *
+ * A visit is linked to a search if:
+ *   - The visit's timestamp >= the search timestamp
+ *   - The visit's timestamp - search timestamp <= windowMs (default: 5 minutes)
+ *
+ * Searches with zero linked visits are still returned (empty `visits` array)
+ * so callers can account for searches that produced no browsing.
+ *
+ * The `intentType` is inferred from the number of linked visits:
+ *   - <= 2 visits: "directed" (found what they needed quickly)
+ *   - >= 3 visits: "undirected" (explored multiple results)
+ *
+ * @param searches - Search queries from `collectBrowserHistory()`
+ * @param visits   - Browser visits from `collectBrowserHistory()`
+ * @param windowMs - Maximum milliseconds after a search to consider a visit linked
+ */
+export function linkSearchesToVisits(
+	searches: SearchQuery[],
+	visits: BrowserVisit[],
+	windowMs = 5 * 60 * 1000,
+): SearchVisitPair[] {
+	return searches.map((search) => {
+		if (!search.time) {
+			return { query: search.query, visits: [], intentType: "directed" };
+		}
+		const searchTimeMs = search.time.getTime();
+		const linked = visits.filter((v) => {
+			if (!v.time) return false;
+			const vt = v.time.getTime();
+			return vt >= searchTimeMs && vt - searchTimeMs <= windowMs;
+		});
+		return {
+			query: search.query,
+			visits: linked,
+			intentType: linked.length <= 2 ? "directed" : "undirected",
+		};
+	});
+}

--- a/src/analyze/knowledge.ts
+++ b/src/analyze/knowledge.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+	ArticleCluster,
 	PatternAnalysis,
 	TemporalCluster,
 	RecurrenceSignal,
@@ -26,6 +27,8 @@ export interface KnowledgeSections {
 	recurrenceNotes: string[];
 	knowledgeDeltaLines: string[];
 	tags: string[];
+	/** Article clusters produced by TF-IDF clustering of substantive browser visits. */
+	articleClusters?: ArticleCluster[];
 }
 
 export function generateKnowledgeSections(

--- a/src/filter/classify.ts
+++ b/src/filter/classify.ts
@@ -46,7 +46,7 @@ export const ENTITY_EXTRACTION_SKIP_DOMAINS = new Set([
  * git commit imperative verbs, email/notification noise, navigation/UI chrome
  * words, and generic tech acronyms.
  */
-const ENTITY_STOPWORDS = new Set([
+export const ENTITY_STOPWORDS = new Set([
 	// Existing entries
 	"The", "This", "That", "How", "What", "Why", "When",
 	// Common English that pass the length check but carry no specificity

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -293,6 +293,44 @@ export function renderMarkdown(
 		lines.push("");
 	}
 
+	// ── Today I Read About (article clusters) ────
+	if (knowledge?.articleClusters && knowledge.articleClusters.length > 0) {
+		lines.push("> [!info]- \u{1F4D6} Today I Read About");
+		for (const cluster of knowledge.articleClusters) {
+			const startTs = cluster.timeRange.start ? formatTime(cluster.timeRange.start) : "";
+			const endTs = cluster.timeRange.end ? formatTime(cluster.timeRange.end) : "";
+			const timeRange = startTs && endTs && startTs !== endTs ? `${startTs}\u2013${endTs}` : startTs;
+			const intentLabel = cluster.intentSignal === "research" ? "Research session"
+				: cluster.intentSignal === "reference" ? "Reference"
+				: cluster.intentSignal === "implementation" ? "Implementation reference"
+				: "Reading session";
+			const articleCount = cluster.articles.length;
+			const articleWord = articleCount === 1 ? "article" : "articles";
+
+			lines.push(`> `);
+			lines.push(`> ### ${escapeForMarkdown(cluster.label)}`);
+			const meta = [intentLabel, timeRange, `${articleCount} ${articleWord}`]
+				.filter(Boolean)
+				.join(" \u00B7 ");
+			lines.push(`> *${meta}*`);
+
+			// Render each article with domain attribution
+			for (let ai = 0; ai < cluster.articles.length; ai++) {
+				const title = cluster.articles[ai];
+				const visit = cluster.visits[ai];
+				let domain = "";
+				try {
+					domain = new URL(visit.url).hostname.replace(/^www\./, "");
+				} catch {
+					// ignore invalid URLs
+				}
+				const domainLabel = domain ? ` \u2014 ${domain}` : "";
+				lines.push(`> - "${escapeForMarkdown(title)}"${domainLabel}`);
+			}
+		}
+		lines.push("");
+	}
+
 	// ── Claude Code sessions ─────────────────────
 	if (claudeSessions.length) {
 		lines.push("## \u{1F916} Claude Code / AI Work");

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,3 +408,27 @@ export interface RAGConfig {
 	minChunkTokens: number;
 	maxChunkTokens: number;
 }
+
+// ── Article Clustering Types ─────────────────────────────
+
+/**
+ * A cluster of thematically related browser visits grouped by TF-IDF
+ * cosine similarity within a session time window.
+ *
+ * Produced by `clusterArticles()` in `src/analyze/clusters.ts`.
+ * Added to `KnowledgeSections.articleClusters` for rendering.
+ */
+export interface ArticleCluster {
+	/** Top-3 TF-IDF terms joined by space — the emergent topic label. */
+	label: string;
+	/** Cleaned page titles of articles in this cluster. */
+	articles: string[];
+	/** Source browser visits (superset of articles, filtered to substantive). */
+	visits: BrowserVisit[];
+	/** Time range of the session: first and last visit timestamps. */
+	timeRange: { start: Date; end: Date };
+	/** Average engagement score across visits in this cluster. */
+	engagementScore: number;
+	/** Inferred reading intent based on domain diversity and revisit patterns. */
+	intentSignal: "research" | "reference" | "implementation" | "browsing";
+}

--- a/tests/unit/analyze/clusters.test.ts
+++ b/tests/unit/analyze/clusters.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from "vitest";
+import {
+	buildTfIdf,
+	cosineSimilarity,
+	labelCluster,
+	clusterArticles,
+} from "../../../src/analyze/clusters";
+import { BrowserVisit } from "../../../src/types";
+
+// ── Helpers ──────────────────────────────────────────────
+
+const BASE_MS = 1_700_000_000_000;
+const MIN = 60_000;
+
+function makeVisit(url: string, offsetMin = 0): BrowserVisit {
+	return {
+		url,
+		title: "",
+		time: new Date(BASE_MS + offsetMin * MIN),
+	};
+}
+
+// ── buildTfIdf ───────────────────────────────────────────
+
+describe("buildTfIdf", () => {
+	it("returns a matrix with one entry per title", () => {
+		const titles = ["typescript generics inference", "react hooks state"];
+		const matrix = buildTfIdf(titles);
+		expect(matrix.size).toBe(2);
+	});
+
+	it("assigns higher TF-IDF to a term that appears in fewer documents", () => {
+		const titles = [
+			"typescript generics inference types",
+			"typescript react integration hooks",
+		];
+		// "typescript" appears in both docs → lower IDF
+		// "generics" appears in only 1 doc → higher IDF
+		const matrix = buildTfIdf(titles);
+		const doc0 = matrix.get("0")!;
+		const tsScore = doc0.get("typescript") ?? 0;
+		const genericsScore = doc0.get("generics") ?? 0;
+		expect(genericsScore).toBeGreaterThan(tsScore);
+	});
+
+	it("assigns lower score to a term appearing in all documents (smooth IDF)", () => {
+		// Smooth IDF: 1 + log(N/df). For N=2, df=2: IDF = 1 + log(1) = 1.
+		// For N=2, df=1: IDF = 1 + log(2) ≈ 1.69.
+		// So shared terms get lower score than unique terms.
+		const titles = ["common word special", "common word unique"];
+		const matrix = buildTfIdf(titles);
+		const doc0 = matrix.get("0")!;
+		const sharedScore = doc0.get("common") ?? 0;
+		const uniqueScore = doc0.get("special") ?? 0;
+		// Unique terms get higher TF-IDF than shared terms
+		expect(uniqueScore).toBeGreaterThan(sharedScore);
+		// Shared term score is > 0 with smooth IDF
+		expect(sharedScore).toBeGreaterThan(0);
+	});
+
+	it("filters out stopwords from the tokeniser", () => {
+		// ENTITY_STOPWORDS includes "HTML", "API", "URL", "CSS", "SDK", "CLI", "IDE"
+		// After lowercasing: "html", "api", "url", "css", "sdk", "cli", "ide" are in STOPWORDS_LOWER
+		// "to" is 2 chars (not > 2) and is also filtered by length
+		const titles = ["HTML API URL CSS SDK to"];
+		const matrix = buildTfIdf(titles);
+		const doc0 = matrix.get("0")!;
+		// All tokens are stopwords or too short — nothing should remain
+		expect(doc0.size).toBe(0);
+	});
+
+	it("handles a single-title corpus without crashing", () => {
+		const titles = ["unique topic deep dive exploration"];
+		const matrix = buildTfIdf(titles);
+		expect(matrix.size).toBe(1);
+	});
+});
+
+// ── cosineSimilarity ─────────────────────────────────────
+
+describe("cosineSimilarity", () => {
+	it("returns 1.0 for identical vectors", () => {
+		const a = new Map([["foo", 1], ["bar", 2]]);
+		const b = new Map([["foo", 1], ["bar", 2]]);
+		expect(cosineSimilarity(a, b)).toBeCloseTo(1.0);
+	});
+
+	it("returns 0 for orthogonal vectors (no shared terms)", () => {
+		const a = new Map([["foo", 1]]);
+		const b = new Map([["bar", 1]]);
+		expect(cosineSimilarity(a, b)).toBeCloseTo(0);
+	});
+
+	it("returns 0 for an empty vector", () => {
+		const a = new Map<string, number>();
+		const b = new Map([["foo", 1]]);
+		expect(cosineSimilarity(a, b)).toBe(0);
+	});
+
+	it("returns a value between 0 and 1 for partially-overlapping vectors", () => {
+		const a = new Map([["typescript", 0.5], ["generics", 0.8]]);
+		const b = new Map([["typescript", 0.5], ["hooks", 0.8]]);
+		const sim = cosineSimilarity(a, b);
+		expect(sim).toBeGreaterThan(0);
+		expect(sim).toBeLessThan(1);
+	});
+});
+
+// ── labelCluster ─────────────────────────────────────────
+
+describe("labelCluster", () => {
+	it("returns top-3 most frequent meaningful words joined by space", () => {
+		const articles = [
+			"TypeScript generic constraints explained",
+			"TypeScript generic type inference guide",
+			"TypeScript generic utility types",
+		];
+		const label = labelCluster(articles);
+		// "typescript" and "generic" appear 3x each; next most frequent differs
+		expect(label).toContain("typescript");
+		expect(label).toContain("generic");
+	});
+
+	it("excludes words of 3 chars or fewer", () => {
+		// All words are <= 3 chars so none pass the > 3 char filter
+		const articles = ["how the use to run and for"];
+		const label = labelCluster(articles);
+		expect(label).toBe("");
+	});
+
+	it("returns empty string for empty articles array", () => {
+		expect(labelCluster([])).toBe("");
+	});
+
+	it("returns only words longer than 3 chars from article text", () => {
+		// "info" is 4 chars, passes filter; "on" and "the" are <= 3 chars, excluded
+		const articles = ["info on the info on the info"];
+		const label = labelCluster(articles);
+		expect(label).toBe("info");
+	});
+});
+
+// ── clusterArticles ──────────────────────────────────────
+
+describe("clusterArticles", () => {
+	it("returns empty array when no visits pass the engagement threshold", () => {
+		const visits = [makeVisit("https://example.com", 0)];
+		const titles = ["Home"];
+		const scores = [0.1]; // below 0.5
+		const clusters = clusterArticles(visits, titles, scores);
+		expect(clusters).toEqual([]);
+	});
+
+	it("returns empty array when there is only one substantive visit (singleton dropped)", () => {
+		const visits = [makeVisit("https://typescriptlang.org", 0)];
+		const titles = ["TypeScript generics constraints tutorial"];
+		const scores = [0.75]; // above 0.5, but only one visit
+		const clusters = clusterArticles(visits, titles, scores);
+		expect(clusters).toEqual([]);
+	});
+
+	it("groups two similar visits into one cluster", () => {
+		const visits = [
+			makeVisit("https://typescriptlang.org/docs/generics", 0),
+			makeVisit("https://stackoverflow.com/q/generics", 5),
+		];
+		const titles = [
+			"TypeScript generic constraints tutorial overview",
+			"TypeScript generic type constraints example solution",
+		];
+		const scores = [0.75, 0.75];
+		const clusters = clusterArticles(visits, titles, scores);
+		expect(clusters).toHaveLength(1);
+		expect(clusters[0].articles).toHaveLength(2);
+	});
+
+	it("splits visits by time gap: two distinct sessions produce separate clusters", () => {
+		// Use a lower similarity threshold (0.1) to focus on testing the time-gap
+		// session boundary logic, not TF-IDF similarity.
+		const SESSION_GAP_MS = 45 * MIN;
+		const LOW_THRESHOLD = 0.1;
+		const visits = [
+			makeVisit("https://typescriptlang.org/docs", 0),
+			makeVisit("https://typescriptlang.org/handbook", 5),
+			// 60-minute gap — beyond session boundary:
+			makeVisit("https://reactjs.org/docs/hooks", 65),
+			makeVisit("https://react.dev/learn/state", 70),
+		];
+		const titles = [
+			"TypeScript generics constraints overview tutorial guide",
+			"TypeScript generics constraints narrowing advanced guide",
+			"React hooks state patterns complete tutorial overview",
+			"React hooks state patterns advanced complete guide",
+		];
+		const scores = [0.75, 0.75, 0.75, 0.75];
+		const clusters = clusterArticles(visits, titles, scores, SESSION_GAP_MS, LOW_THRESHOLD);
+		// The two groups are separated by > 45 minutes → should form distinct clusters
+		expect(clusters.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("each cluster has a non-empty label", () => {
+		const visits = [
+			makeVisit("https://typescriptlang.org/docs", 0),
+			makeVisit("https://stackoverflow.com/q/ts", 5),
+		];
+		const titles = [
+			"TypeScript generic constraints explained tutorial",
+			"TypeScript generic type inference guide",
+		];
+		const scores = [0.75, 0.75];
+		const clusters = clusterArticles(visits, titles, scores);
+		if (clusters.length > 0) {
+			expect(clusters[0].label.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("cluster timeRange.start <= timeRange.end", () => {
+		const visits = [
+			makeVisit("https://typescriptlang.org/docs", 0),
+			makeVisit("https://stackoverflow.com/q/ts", 10),
+		];
+		const titles = [
+			"TypeScript generic constraints explained tutorial",
+			"TypeScript generic type inference advanced guide",
+		];
+		const scores = [0.75, 0.75];
+		const clusters = clusterArticles(visits, titles, scores);
+		for (const cluster of clusters) {
+			expect(cluster.timeRange.start.getTime()).toBeLessThanOrEqual(
+				cluster.timeRange.end.getTime(),
+			);
+		}
+	});
+
+	it("infers 'research' intent when 3+ distinct domains are in a cluster", () => {
+		const visits = [
+			makeVisit("https://typescriptlang.org/docs", 0),
+			makeVisit("https://stackoverflow.com/q/ts", 5),
+			makeVisit("https://mdn.mozilla.org/js/types", 10),
+		];
+		const titles = [
+			"TypeScript generic constraints tutorial guide",
+			"TypeScript generic type inference overview",
+			"TypeScript type system generics reference",
+		];
+		const scores = [0.75, 0.75, 0.75];
+		const clusters = clusterArticles(visits, titles, scores);
+		if (clusters.length > 0) {
+			expect(clusters[0].intentSignal).toBe("research");
+		}
+	});
+
+	it("engagementScore is between 0 and 1 for all clusters", () => {
+		const visits = [
+			makeVisit("https://typescriptlang.org/docs", 0),
+			makeVisit("https://stackoverflow.com/q/ts", 5),
+		];
+		const titles = [
+			"TypeScript generic constraints explained tutorial",
+			"TypeScript generic type inference advanced guide",
+		];
+		const scores = [0.75, 0.60];
+		const clusters = clusterArticles(visits, titles, scores);
+		for (const cluster of clusters) {
+			expect(cluster.engagementScore).toBeGreaterThan(0);
+			expect(cluster.engagementScore).toBeLessThanOrEqual(1);
+		}
+	});
+});

--- a/tests/unit/analyze/engagement.test.ts
+++ b/tests/unit/analyze/engagement.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { computeEngagementScore } from "../../../src/analyze/engagement";
+import { BrowserVisit } from "../../../src/types";
+import { SearchVisitPair } from "../../../src/analyze/intent";
+
+// ── Helpers ──────────────────────────────────────────────
+
+function makeVisit(url: string, timeMs = 0): BrowserVisit {
+	return { url, title: "", time: new Date(timeMs) };
+}
+
+function makeSearch(visits: BrowserVisit[]): SearchVisitPair {
+	return { query: "some query", visits, intentType: "directed" };
+}
+
+// ── computeEngagementScore ───────────────────────────────
+
+describe("computeEngagementScore", () => {
+	// ── Baseline score ───────────────────────────
+	it("returns 0 for an empty cleaned title with no other signals", () => {
+		const visit = makeVisit("https://example.com");
+		const score = computeEngagementScore(visit, "", [visit], []);
+		expect(score).toBe(0);
+	});
+
+	// ── Title quality (+0.25) ────────────────────
+	it("adds 0.25 for a cleaned title with 5 or more words", () => {
+		const visit = makeVisit("https://example.com");
+		const title = "How to use TypeScript generic constraints"; // 7 words
+		const score = computeEngagementScore(visit, title, [visit], []);
+		expect(score).toBeCloseTo(0.25);
+	});
+
+	it("does not add title bonus for a 4-word title", () => {
+		const visit = makeVisit("https://example.com");
+		const title = "TypeScript generic constraints explained"; // 4 words
+		const score = computeEngagementScore(visit, title, [visit], []);
+		expect(score).toBe(0);
+	});
+
+	it("does not add title bonus for an empty cleaned title", () => {
+		const visit = makeVisit("https://example.com");
+		const score = computeEngagementScore(visit, "", [visit], []);
+		expect(score).toBe(0);
+	});
+
+	// ── Revisit signal (+0.20) ───────────────────
+	it("adds 0.20 when the same URL appears more than once in todayVisits", () => {
+		const visit = makeVisit("https://example.com");
+		const todayVisits = [visit, visit]; // same URL twice
+		const score = computeEngagementScore(visit, "", todayVisits, []);
+		expect(score).toBeCloseTo(0.20);
+	});
+
+	it("does not add revisit bonus when URL appears only once", () => {
+		const visit = makeVisit("https://example.com");
+		const otherVisit = makeVisit("https://other.com");
+		const todayVisits = [visit, otherVisit];
+		const score = computeEngagementScore(visit, "", todayVisits, []);
+		expect(score).toBe(0);
+	});
+
+	// ── Search-intent linkage (+0.25) ────────────
+	it("adds 0.25 when the visit is linked to a search query", () => {
+		const visit = makeVisit("https://typescriptlang.org/docs");
+		const searchLink = makeSearch([visit]);
+		const score = computeEngagementScore(visit, "", [visit], [searchLink]);
+		expect(score).toBeCloseTo(0.25);
+	});
+
+	it("does not add search bonus when visit URL is not in any search link", () => {
+		const visit = makeVisit("https://typescriptlang.org/docs");
+		const otherVisit = makeVisit("https://other.com");
+		const searchLink = makeSearch([otherVisit]);
+		const score = computeEngagementScore(visit, "", [visit], [searchLink]);
+		expect(score).toBe(0);
+	});
+
+	// ── Technical terms (+0.15) ──────────────────
+	it("adds 0.15 for a version number in the cleaned title", () => {
+		const visit = makeVisit("https://example.com");
+		const title = "Node.js 20.0 upgrade guide"; // "20.0" matches
+		const score = computeEngagementScore(visit, title, [visit], []);
+		expect(score).toBeCloseTo(0.15);
+	});
+
+	it("adds 0.15 for an Error suffix in the cleaned title (plus 0.25 for 6 words = 0.40)", () => {
+		const visit = makeVisit("https://example.com");
+		// 6 words (+0.25) + TypeError matches \w+Error (+0.15) = 0.40
+		const title = "TypeError cannot read properties of undefined";
+		const score = computeEngagementScore(visit, title, [visit], []);
+		expect(score).toBeCloseTo(0.40);
+	});
+
+	it("adds 0.15 for a method call pattern in the cleaned title (plus 0.25 for 7 words = 0.40)", () => {
+		const visit = makeVisit("https://example.com");
+		// 7 words (+0.25) + Array.reduce() matches \w+\(\) (+0.15) = 0.40
+		const title = "Using Array.reduce() to flatten nested arrays";
+		const score = computeEngagementScore(visit, title, [visit], []);
+		expect(score).toBeCloseTo(0.40);
+	});
+
+	it("adds 0.15 for a version number in isolation (short title, no word bonus)", () => {
+		const visit = makeVisit("https://example.com");
+		// 4 words → no word bonus. "20.0" matches \d+\.\d+ → +0.15
+		const title = "Node 20.0 changelog";
+		const score = computeEngagementScore(visit, title, [visit], []);
+		expect(score).toBeCloseTo(0.15);
+	});
+
+	// ── Combined scores ──────────────────────────
+	it("returns 0.50 for title + search link (crosses the substantive threshold)", () => {
+		const visit = makeVisit("https://example.com");
+		const title = "How to use TypeScript generic constraints"; // 7 words → +0.25
+		const searchLink = makeSearch([visit]); // linked to search → +0.25
+		const score = computeEngagementScore(visit, title, [visit], [searchLink]);
+		expect(score).toBeCloseTo(0.50);
+	});
+
+	it("returns 0.65 for title + revisit + search link", () => {
+		const visit = makeVisit("https://example.com");
+		const title = "How to use TypeScript generic constraints"; // +0.25
+		const todayVisits = [visit, visit]; // revisit → +0.20
+		const searchLink = makeSearch([visit]); // search link → +0.25
+		const score = computeEngagementScore(visit, title, todayVisits, [searchLink]);
+		expect(score).toBeCloseTo(0.70);
+	});
+
+	it("caps at 1.0 even when all signals are present", () => {
+		const visit = makeVisit("https://example.com");
+		const title = "TypeError: reduce() on empty array without initial value 2.0"; // words + Error + ()
+		const todayVisits = [visit, visit]; // revisit
+		const searchLink = makeSearch([visit]); // search link
+		const score = computeEngagementScore(visit, title, todayVisits, [searchLink]);
+		expect(score).toBeLessThanOrEqual(1.0);
+	});
+
+	// ── Threshold boundary ───────────────────────
+	it("a title-only visit is below the 0.5 substantive threshold", () => {
+		const visit = makeVisit("https://example.com");
+		const title = "Understanding the JavaScript event loop in depth"; // 8 words → +0.25
+		const score = computeEngagementScore(visit, title, [visit], []);
+		expect(score).toBeLessThan(0.5);
+	});
+
+	it("a revisit-only visit is below the 0.5 substantive threshold", () => {
+		const visit = makeVisit("https://example.com");
+		const todayVisits = [visit, visit]; // revisit → +0.20
+		const score = computeEngagementScore(visit, "", todayVisits, []);
+		expect(score).toBeLessThan(0.5);
+	});
+});

--- a/tests/unit/analyze/intent.test.ts
+++ b/tests/unit/analyze/intent.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { linkSearchesToVisits } from "../../../src/analyze/intent";
+import { BrowserVisit, SearchQuery } from "../../../src/types";
+
+// ── Helpers ──────────────────────────────────────────────
+
+function makeVisit(url: string, timeMs: number): BrowserVisit {
+	return {
+		url,
+		title: "Some title",
+		time: new Date(timeMs),
+	};
+}
+
+function makeSearch(query: string, timeMs: number): SearchQuery {
+	return {
+		query,
+		time: new Date(timeMs),
+		engine: "google.com",
+	};
+}
+
+// ── linkSearchesToVisits ──────────────────────────────────
+
+describe("linkSearchesToVisits", () => {
+	const BASE = 1_700_000_000_000; // arbitrary base timestamp
+	const MIN = 60_000;
+	const WIN = 5 * MIN; // default 5-minute window
+
+	it("returns empty array when searches is empty", () => {
+		const visits = [makeVisit("https://example.com", BASE + 30_000)];
+		expect(linkSearchesToVisits([], visits)).toEqual([]);
+	});
+
+	it("returns pairs with empty visits when no visits fall in the window", () => {
+		const searches = [makeSearch("typescript generics", BASE)];
+		const visits = [makeVisit("https://example.com", BASE + WIN + 1_000)]; // just outside window
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result).toHaveLength(1);
+		expect(result[0].visits).toHaveLength(0);
+	});
+
+	it("links a visit that is exactly at the search time (gap = 0)", () => {
+		const searches = [makeSearch("typescript generics", BASE)];
+		const visits = [makeVisit("https://typescriptlang.org/docs", BASE)];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].visits).toHaveLength(1);
+	});
+
+	it("links a visit at exactly windowMs after the search", () => {
+		const searches = [makeSearch("typescript generics", BASE)];
+		const visits = [makeVisit("https://typescriptlang.org/docs", BASE + WIN)];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].visits).toHaveLength(1);
+	});
+
+	it("does not link a visit before the search time", () => {
+		const searches = [makeSearch("typescript generics", BASE)];
+		const visits = [makeVisit("https://typescriptlang.org/docs", BASE - 1_000)]; // before search
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].visits).toHaveLength(0);
+	});
+
+	it("links multiple visits within the window", () => {
+		const searches = [makeSearch("react hooks", BASE)];
+		const visits = [
+			makeVisit("https://reactjs.org/docs/hooks-intro.html", BASE + MIN),
+			makeVisit("https://reactjs.org/docs/hooks-state.html", BASE + 2 * MIN),
+			makeVisit("https://react.dev/learn/managing-state", BASE + 4 * MIN),
+		];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].visits).toHaveLength(3);
+	});
+
+	// ── intentType inference ─────────────────────
+
+	it("returns 'directed' when 1 visit is linked", () => {
+		const searches = [makeSearch("typescript generics", BASE)];
+		const visits = [makeVisit("https://typescriptlang.org/docs", BASE + 30_000)];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].intentType).toBe("directed");
+	});
+
+	it("returns 'directed' when 2 visits are linked", () => {
+		const searches = [makeSearch("typescript generics", BASE)];
+		const visits = [
+			makeVisit("https://typescriptlang.org/docs", BASE + 30_000),
+			makeVisit("https://stackoverflow.com/q/1", BASE + MIN),
+		];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].intentType).toBe("directed");
+	});
+
+	it("returns 'undirected' when 3 or more visits are linked", () => {
+		const searches = [makeSearch("css grid layout", BASE)];
+		const visits = [
+			makeVisit("https://css-tricks.com/a", BASE + 30_000),
+			makeVisit("https://mdn.mozilla.org/b", BASE + MIN),
+			makeVisit("https://web.dev/c", BASE + 2 * MIN),
+		];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].intentType).toBe("undirected");
+	});
+
+	it("returns 'directed' with 0 visits (no result to direct to)", () => {
+		const searches = [makeSearch("something obscure", BASE)];
+		const result = linkSearchesToVisits(searches, []);
+		expect(result[0].intentType).toBe("directed");
+	});
+
+	// ── multiple searches ────────────────────────
+
+	it("handles multiple searches independently", () => {
+		const searches = [
+			makeSearch("query A", BASE),
+			makeSearch("query B", BASE + 10 * MIN),
+		];
+		const visits = [
+			makeVisit("https://a.com", BASE + MIN),
+			makeVisit("https://b.com", BASE + 11 * MIN),
+		];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result).toHaveLength(2);
+		expect(result[0].visits[0].url).toBe("https://a.com");
+		expect(result[1].visits[0].url).toBe("https://b.com");
+	});
+
+	it("preserves the search query string in the result", () => {
+		const searches = [makeSearch("vitest mocking modules", BASE)];
+		const result = linkSearchesToVisits(searches, []);
+		expect(result[0].query).toBe("vitest mocking modules");
+	});
+
+	// ── null-time handling ───────────────────────
+
+	it("returns empty visits when search has null time", () => {
+		const searches: SearchQuery[] = [{ query: "foo", time: null, engine: "google.com" }];
+		const visits = [makeVisit("https://example.com", BASE)];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].visits).toHaveLength(0);
+	});
+
+	it("skips visits with null time", () => {
+		const searches = [makeSearch("bar", BASE)];
+		const visits: BrowserVisit[] = [
+			{ url: "https://example.com", title: "Foo", time: null },
+		];
+		const result = linkSearchesToVisits(searches, visits);
+		expect(result[0].visits).toHaveLength(0);
+	});
+
+	// ── custom windowMs ──────────────────────────
+
+	it("respects a custom windowMs", () => {
+		const CUSTOM_WIN = 1 * MIN; // 1-minute window
+		const searches = [makeSearch("rust ownership", BASE)];
+		const visits = [
+			makeVisit("https://doc.rust-lang.org/a", BASE + 30_000), // within 1 min
+			makeVisit("https://doc.rust-lang.org/b", BASE + 2 * MIN), // outside 1 min
+		];
+		const result = linkSearchesToVisits(searches, visits, CUSTOM_WIN);
+		expect(result[0].visits).toHaveLength(1);
+	});
+});

--- a/tests/unit/collect/browser-title-cleaning.test.ts
+++ b/tests/unit/collect/browser-title-cleaning.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { cleanTitle } from "../../../src/collect/browser";
+
+// ── cleanTitle ───────────────────────────────────────────
+
+describe("cleanTitle", () => {
+	// ── Empty / falsy input ──────────────────────
+	it("returns empty string for empty input", () => {
+		expect(cleanTitle("")).toBe("");
+	});
+
+	// ── Brand suffix stripping ───────────────────
+	it("strips ' | GitHub' suffix", () => {
+		expect(cleanTitle("obsidian-community/obsidian-api | GitHub")).toBe(
+			"obsidian-community/obsidian-api",
+		);
+	});
+
+	it("strips ' · GitHub' suffix", () => {
+		expect(cleanTitle("Pull Request #42 · org/repo · GitHub")).toBe(
+			"Pull Request #42",
+		);
+	});
+
+	it("strips ' - GitHub' suffix and splits on remaining ' - ' separator", () => {
+		// After stripping " - GitHub": "Releases - org/repo"
+		// After splitting on " - ": ["Releases", "org/repo"] — both 8 chars, first wins
+		const result = cleanTitle("Releases - org/repo - GitHub");
+		expect(["Releases", "org/repo"]).toContain(result);
+	});
+
+	it("strips ' - Stack Overflow' suffix", () => {
+		expect(cleanTitle("How to deep clone an object in JavaScript - Stack Overflow")).toBe(
+			"How to deep clone an object in JavaScript",
+		);
+	});
+
+	it("strips ' | MDN Web Docs' suffix", () => {
+		expect(cleanTitle("Array.prototype.map() | MDN Web Docs")).toBe(
+			"Array.prototype.map()",
+		);
+	});
+
+	it("strips ' | TypeScript' suffix and splits on remaining ' - ' separator", () => {
+		// Strip " | TypeScript" → "TypeScript: Handbook - Generics"
+		// Split on " - " → ["TypeScript: Handbook", "Generics"]
+		// Longest wins: "TypeScript: Handbook"
+		expect(cleanTitle("TypeScript: Handbook - Generics | TypeScript")).toBe(
+			"TypeScript: Handbook",
+		);
+	});
+
+	it("strips ' | YouTube' suffix", () => {
+		expect(cleanTitle("React hooks in 10 minutes | YouTube")).toBe(
+			"React hooks in 10 minutes",
+		);
+	});
+
+	it("strips ' | Wikipedia' suffix", () => {
+		expect(cleanTitle("Dijkstra's algorithm | Wikipedia")).toBe(
+			"Dijkstra's algorithm",
+		);
+	});
+
+	it("strips ' - Wikipedia' suffix", () => {
+		expect(cleanTitle("Merge sort - Wikipedia")).toBe("Merge sort");
+	});
+
+	it("strips ' | Reddit' suffix", () => {
+		expect(cleanTitle("Why is TypeScript so verbose? | Reddit")).toBe(
+			"Why is TypeScript so verbose?",
+		);
+	});
+
+	// ── Separator splitting ──────────────────────
+	it("splits on ' | ' separator and takes left portion", () => {
+		expect(cleanTitle("Obsidian Plugin API reference | Obsidian")).toBe(
+			"Obsidian Plugin API reference",
+		);
+	});
+
+	it("splits on ' — ' (em dash) separator", () => {
+		expect(cleanTitle("Generic constraint not assignable to type 'object' — Stack Overflow")).toBe(
+			"Generic constraint not assignable to type 'object'",
+		);
+	});
+
+	it("splits on ' - ' separator with surrounding spaces", () => {
+		expect(cleanTitle("typescript - How to use generic constraints - Stack Overflow")).toBe(
+			"How to use generic constraints",
+		);
+	});
+
+	it("splits on ' · ' separator and takes the longest segment", () => {
+		expect(cleanTitle("Vitest · Fast unit testing framework")).toBe(
+			"Fast unit testing framework",
+		);
+	});
+
+	// ── Nav-noise rejection ──────────────────────
+	it("returns empty string for 'Home' (nav noise)", () => {
+		expect(cleanTitle("Home")).toBe("");
+	});
+
+	it("returns empty string for 'Dashboard' (nav noise)", () => {
+		expect(cleanTitle("Dashboard")).toBe("");
+	});
+
+	it("returns empty string for 'Dashboard | HubSpot' (nav noise after stripping)", () => {
+		// After separator split: "Dashboard" → nav noise
+		expect(cleanTitle("Dashboard | HubSpot")).toBe("");
+	});
+
+	it("returns empty string for 'Login' (nav noise)", () => {
+		expect(cleanTitle("Login")).toBe("");
+	});
+
+	it("returns empty string for 'Settings' (nav noise)", () => {
+		expect(cleanTitle("Settings")).toBe("");
+	});
+
+	it("returns empty string for 'New Tab' (nav noise)", () => {
+		expect(cleanTitle("New Tab")).toBe("");
+	});
+
+	it("returns empty string for 'Google' (nav noise)", () => {
+		expect(cleanTitle("Google")).toBe("");
+	});
+
+	it("returns empty string for 'Search Results' (nav noise)", () => {
+		expect(cleanTitle("Search Results")).toBe("");
+	});
+
+	// ── Short title rejection ────────────────────
+	it("returns empty string for a title shorter than 5 chars after cleaning", () => {
+		// "OK" → length 2, rejected
+		expect(cleanTitle("OK")).toBe("");
+	});
+
+	it("returns empty string for 4-char title after cleaning", () => {
+		// "Atom" → 4 chars, rejected
+		expect(cleanTitle("Atom")).toBe("");
+	});
+
+	it("keeps a title exactly 5 chars long", () => {
+		// "Cargo" → 5 chars, kept
+		expect(cleanTitle("Cargo")).toBe("Cargo");
+	});
+
+	// ── Real-world end-to-end examples ──────────
+	it("cleans a real TypeScript handbook URL title", () => {
+		// Strip " | TypeScript" → "TypeScript: Documentation - Generics"
+		// Split on " - " → ["TypeScript: Documentation", "Generics"]
+		// Longest segment wins: "TypeScript: Documentation"
+		expect(cleanTitle("TypeScript: Documentation - Generics | TypeScript")).toBe(
+			"TypeScript: Documentation",
+		);
+	});
+
+	it("cleans a real Stack Overflow question title", () => {
+		// Strip " - Stack Overflow" → "javascript - How to deep copy an array in JavaScript"
+		// Split on " - " → ["javascript", "How to deep copy an array in JavaScript"]
+		// Longest segment wins: "How to deep copy an array in JavaScript" (39 chars vs 10)
+		expect(
+			cleanTitle("javascript - How to deep copy an array in JavaScript - Stack Overflow"),
+		).toBe("How to deep copy an array in JavaScript");
+	});
+
+	it("preserves a clean article title with no separators or brand suffixes", () => {
+		expect(cleanTitle("Understanding the JavaScript Event Loop")).toBe(
+			"Understanding the JavaScript Event Loop",
+		);
+	});
+
+	it("strips brand suffix before splitting separators", () => {
+		// Without suffix stripping, split on ' - GitHub' would happen incorrectly
+		expect(cleanTitle("Fix TypeError in reduce callback - GitHub")).toBe(
+			"Fix TypeError in reduce callback",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Transforms the Browser Activity section from a raw domain/URL dump into a semantic knowledge trail. Zero LLM calls — all pure TypeScript.

### New pipeline stages (all offline):
1. **Title cleaning** (`src/collect/browser.ts`): `cleanTitle()` strips brand suffixes ("- Stack Overflow", "| GitHub", etc.), splits on separators, rejects navigation noise (Login, Home, Dashboard, etc.) — exported for use by dedup and clustering
2. **Search-visit linkage** (`src/analyze/intent.ts`): pairs each search query with visits within a 5-minute window; infers directed (≤2 visits) vs undirected intent
3. **Engagement scoring** (`src/analyze/engagement.ts`): scores 0–1 from title quality, revisit count, search linkage, and technical terms; threshold 0.5 = "substantive"
4. **TF-IDF clustering** (`src/analyze/clusters.ts`): groups substantive visits by semantic similarity (cosine ≥ 0.3) within 45-minute session gaps; labels clusters from top terms; infers research/reference/implementation/browsing intent

### Renderer change:
New "Today I Read About" collapsed callout after Searches section:
```markdown
> [!info]- 📖 Today I Read About
> ### TypeScript generics type inference
> *Research session · 10:15–11:02 AM · 4 articles*
> - "TypeScript Handbook: Generics" — TypeScript docs
> ...
```

### Also:
- Updated `pickBest()` in `dedup.ts` to use `cleanTitle()` length (strips brand noise from representative selection)
- `ENTITY_STOPWORDS` exported from `classify.ts` for use in TF-IDF tokenizer
- `ArticleCluster` type added to `types.ts`; wired through `KnowledgeSections` → `renderMarkdown()`

## Test plan

- [x] `tests/unit/collect/browser-title-cleaning.test.ts` — 30 tests
- [x] `tests/unit/analyze/intent.test.ts` — 15 tests
- [x] `tests/unit/analyze/engagement.test.ts` — 17 tests
- [x] `tests/unit/analyze/clusters.test.ts` — 21 tests
- [x] `npm run test` — 862 passed | 45 skipped
- [x] `npm run build` — clean
- [x] `npm run lint` — clean