### PR TITLE
feat: semantic extraction layer (commit work units, task sessions, cross-source fusion)

### DIFF
--- a/src/analyze/commits.ts
+++ b/src/analyze/commits.ts
@@ -1,0 +1,369 @@
+/**
+ * Commit Work Unit Analysis — Semantic Extraction Layer.
+ *
+ * Parses conventional commit messages, classifies developer intent (work mode),
+ * and groups related commits into coherent work units using session gap detection
+ * and scope/mode clustering.
+ *
+ * No LLM calls. No network. No external libraries.
+ *
+ * Research basis:
+ *   - Mockus & Votta (ICSE 2000): commit type → developer intent taxonomy
+ *   - Sliwerski/Zimmermann/Zeller (MSR 2005): bug keyword heuristics
+ *   - Tian et al. (ICSE 2022): why-detection patterns, ~38% of commits have why
+ *   - Hindle et al. (MSR 2008): change statistics as intent cross-check
+ *   - Alali et al. (ICPC 2008): 90-minute session gap (git-hours validated)
+ */
+
+import { CommitWorkMode, CommitWorkUnit, GitCommit, ParsedCommit } from "../types";
+
+// ── Conventional Commit Parsing ───────────────────────────
+
+// Positional groups: [1]=type, [2]=scope (optional), [3]=breaking (optional), [4]=description
+// Named capturing groups require ES2018+; this project targets ES6.
+const CONVENTIONAL_COMMIT_RE =
+	/^(feat|fix|refactor|docs|test|chore|build|ci|perf|revert|style)(?:\(([^)]+)\))?(!)?\s*:\s*(.+)$/i;
+
+/**
+ * Parse a commit message into its conventional commit components.
+ * Handles non-conventional commits by returning empty type and full message as description.
+ */
+export function parseConventionalCommit(message: string): ParsedCommit {
+	const m = CONVENTIONAL_COMMIT_RE.exec(message.trim());
+	if (m) {
+		return {
+			type: m[1].toLowerCase(),
+			scope: m[2] ?? null,
+			breaking: m[3] === "!",
+			description: m[4].trim(),
+			raw: message,
+		};
+	}
+	return {
+		type: "",
+		scope: null,
+		breaking: false,
+		description: message.trim(),
+		raw: message,
+	};
+}
+
+// ── Work Mode Classification ──────────────────────────────
+
+/**
+ * Maps conventional commit types directly to CommitWorkMode.
+ * Only types that have a 1:1 mapping are listed here; others use fallbacks.
+ */
+const CONVENTIONAL_TYPE_TO_WORK_MODE: Record<string, CommitWorkMode> = {
+	feat:     "building",
+	fix:      "debugging",
+	refactor: "restructuring",
+	test:     "testing",
+	docs:     "documenting",
+	chore:    "infrastructure",
+	build:    "infrastructure",
+	ci:       "infrastructure",
+	perf:     "optimizing",
+	revert:   "reverting",
+	style:    "restructuring",
+};
+
+// Keyword fallback patterns (Sliwerski/Zimmermann/Zeller SZZ heuristics)
+const BUG_KEYWORDS_RE    = /\b(fix(es|ed|ing)?|bug|defect|error|fault|issue|problem|crash(es|ed)?|fail(s|ed|ure)?|wrong|incorrect|broken|repair|patch|resolve[sd]?)\b/i;
+const FEAT_KEYWORDS_RE   = /\b(add|implement|introduce|create|new|support|enable|allow|feature)\b/i;
+const REFACTOR_KEYWORDS_RE = /\b(refactor|clean|cleanup|reorganize|restructure|rename|move|extract|simplify|improve|optimize)\b/i;
+const TEST_KEYWORDS_RE   = /\b(test|spec|coverage|assert|mock|fixture)\b/i;
+const DOCS_KEYWORDS_RE   = /\b(doc|readme|comment|documentation|changelog|license)\b/i;
+const REVERT_KEYWORDS_RE = /\b(revert|rollback|undo)\b/i;
+
+// Generic/WIP commit detection
+const GENERIC_COMMIT_PATTERNS: RegExp[] = [
+	/^(wip|work in progress)$/i,
+	/^(update|updates)$/i,
+	/^(fix|fixes|fixed)$/i,      // bare "fix" with no object
+	/^(cleanup|clean\s+up|clean)$/i,
+	/^(misc|various|minor|small|quick|tiny)(\s+(fix|change|update|tweak))?$/i,
+	/^(temp|tmp|temporary)$/i,
+	/^(changes?|changes made)$/i,
+];
+
+/**
+ * Determine the CommitWorkMode for a commit using a prioritised decision tree:
+ *   1. Parse conventional commit prefix → direct type mapping
+ *   2. No prefix → apply BUG/FEAT/REFACTOR/TEST/DOCS/REVERT keyword patterns
+ *   3. No keyword match → infer from insertions/deletions ratio (Hindle et al. MSR 2008)
+ *   4. All else fails → "tweaking"
+ */
+export function classifyWorkMode(
+	commit: ParsedCommit,
+	insertions: number,
+	deletions: number,
+): CommitWorkMode {
+	// 1. Conventional type
+	if (commit.type && CONVENTIONAL_TYPE_TO_WORK_MODE[commit.type]) {
+		return CONVENTIONAL_TYPE_TO_WORK_MODE[commit.type];
+	}
+
+	const text = commit.description + " " + commit.raw;
+
+	// 2. Keyword fallback
+	if (REVERT_KEYWORDS_RE.test(text)) return "reverting";
+	if (TEST_KEYWORDS_RE.test(text)) return "testing";
+	if (DOCS_KEYWORDS_RE.test(text)) return "documenting";
+	if (BUG_KEYWORDS_RE.test(text)) return "debugging";
+	if (FEAT_KEYWORDS_RE.test(text)) return "building";
+	if (REFACTOR_KEYWORDS_RE.test(text)) return "restructuring";
+
+	// 3. Change statistics ratio heuristic
+	const total = insertions + deletions;
+	if (total > 0) {
+		if (insertions > 0 && deletions === 0) return "building";
+		if (deletions > 0 && insertions === 0) return "restructuring"; // cleanup/removal
+		const ratio = insertions / (deletions || 1);
+		if (ratio > 3) return "building";
+		if (ratio < 0.33) return "restructuring"; // deletions >> insertions
+	}
+
+	// 4. Fallback
+	return "tweaking";
+}
+
+// ── Why-Clause Detection ──────────────────────────────────
+
+// Tian et al. (ICSE 2022) why-patterns — only ~38% of commits contain a "why"
+const WHY_PATTERNS: RegExp[] = [
+	/\bso\s+that\b/i,
+	// "so " not followed by common adverbs/adjectives that are not causal
+	/\bso\s+(?!far|long|much|many|good|bad|great|well|often|little|few)\w/i,
+	/\bbecause\b/i,
+	/\bsince\b/i,
+	/\bin\s+order\s+to\b/i,
+	/\bto\s+avoid\b/i,
+	/\bprevents?\b/i,
+	/\bfixes?\s+#\d+/i,
+	/\bcloses?\s+#\d+/i,
+	/\baddresses\b/i,
+	/\bensures?\b/i,
+	/\bhandles?\b/i,
+	/\botherwise\b/i,
+];
+
+function extractWhyClause(message: string): string | null {
+	for (const pattern of WHY_PATTERNS) {
+		const m = pattern.exec(message);
+		if (m) {
+			// Return the fragment from the why-marker to end, capped at 120 chars
+			return message.slice(m.index, m.index + 120).trim();
+		}
+	}
+	return null;
+}
+
+function isGenericMessage(message: string): boolean {
+	const trimmed = message.trim();
+	return GENERIC_COMMIT_PATTERNS.some((re) => re.test(trimmed));
+}
+
+// ── Session Detection ─────────────────────────────────────
+
+/** 90-minute session gap (validated by git-hours tooling, Alali et al. ICPC 2008). */
+const SESSION_GAP_MS = 90 * 60 * 1000;
+
+/**
+ * Determine if two commit times cross a session boundary.
+ * A session boundary exists when:
+ *   - The gap between commits exceeds SESSION_GAP_MS, OR
+ *   - The commits are on different calendar days (midnight boundary)
+ */
+function isSessionBoundary(earlier: Date, later: Date): boolean {
+	if (later.getTime() - earlier.getTime() > SESSION_GAP_MS) return true;
+	if (earlier.toDateString() !== later.toDateString()) return true;
+	return false;
+}
+
+// ── Work Unit Clustering ──────────────────────────────────
+
+/**
+ * Extract a label for a work unit in priority order:
+ *   1. Scope field if consistent across commits (e.g. "render", "summarize")
+ *   2. Repo name if single-repo session + work mode
+ *   3. Most common meaningful noun from descriptions
+ */
+function buildWorkUnitLabel(
+	commits: GitCommit[],
+	parsedCommits: ParsedCommit[],
+	workMode: CommitWorkMode,
+): string {
+	// 1. Consistent scope
+	const scopes = parsedCommits
+		.map((p) => p.scope)
+		.filter((s): s is string => s !== null && s.trim().length > 0);
+	if (scopes.length > 0) {
+		const scopeCounts: Record<string, number> = {};
+		for (const s of scopes) {
+			scopeCounts[s] = (scopeCounts[s] ?? 0) + 1;
+		}
+		const topScope = Object.entries(scopeCounts).sort((a, b) => b[1] - a[1])[0][0];
+		return `Feature work: ${topScope}`;
+	}
+
+	// 2. Single-repo session
+	const repos = [...new Set(commits.map((c) => c.repo))];
+	if (repos.length === 1 && repos[0]) {
+		return `${repos[0]}: ${workMode}`;
+	}
+
+	// 3. Most common noun phrase across descriptions (words > 3 chars, not stopwords)
+	const LABEL_STOPWORDS = new Set([
+		"with", "from", "that", "this", "into", "when", "then", "also",
+		"some", "have", "more", "each", "such", "just", "very", "only",
+	]);
+	const wordCounts: Record<string, number> = {};
+	for (const p of parsedCommits) {
+		const words = p.description
+			.toLowerCase()
+			.replace(/[^\w\s-]/g, " ")
+			.split(/\s+/)
+			.filter((w) => w.length > 3 && !LABEL_STOPWORDS.has(w));
+		for (const w of words) {
+			wordCounts[w] = (wordCounts[w] ?? 0) + 1;
+		}
+	}
+	const topWords = Object.entries(wordCounts)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 3)
+		.map(([w]) => w);
+
+	if (topWords.length > 0) {
+		return topWords.join(" ");
+	}
+
+	// Ultimate fallback
+	return workMode;
+}
+
+/**
+ * Determine the dominant work mode across a set of commits.
+ * Picks the most frequent work mode (excluding "tweaking" if any other mode is present).
+ */
+function dominantWorkMode(modes: CommitWorkMode[]): CommitWorkMode {
+	if (modes.length === 0) return "tweaking";
+	const counts: Record<string, number> = {};
+	for (const m of modes) {
+		counts[m] = (counts[m] ?? 0) + 1;
+	}
+	// Prefer non-tweaking modes
+	const nonTweaking = Object.entries(counts).filter(([m]) => m !== "tweaking");
+	if (nonTweaking.length > 0) {
+		return nonTweaking.sort((a, b) => b[1] - a[1])[0][0] as CommitWorkMode;
+	}
+	return "tweaking";
+}
+
+/**
+ * Group a flat list of GitCommit objects into coherent CommitWorkUnit objects
+ * using a two-pass algorithm:
+ *
+ * Pass 1 — Session detection (90-min gap + midnight boundary):
+ *   Sort commits chronologically. Split into sessions on gap boundaries.
+ *
+ * Pass 2 — Work unit clustering within sessions:
+ *   Group by dominant work mode. Split debugging commits from building commits.
+ *   Multi-repo sessions are split by repo.
+ *
+ * @param commits  Flat list of GitCommit objects (any order; sorted internally).
+ */
+export function groupCommitsIntoWorkUnits(commits: GitCommit[]): CommitWorkUnit[] {
+	if (commits.length === 0) return [];
+
+	// Sort chronologically (oldest first for session boundary detection)
+	const sorted = [...commits].sort((a, b) => {
+		const ta = a.time?.getTime() ?? 0;
+		const tb = b.time?.getTime() ?? 0;
+		return ta - tb;
+	});
+
+	// ── Pass 1: Session detection ──────────────────────────
+	const sessions: GitCommit[][] = [];
+	let currentSession: GitCommit[] = [sorted[0]];
+
+	for (let i = 1; i < sorted.length; i++) {
+		const prev = sorted[i - 1];
+		const curr = sorted[i];
+		const prevTime = prev.time;
+		const currTime = curr.time;
+
+		if (prevTime && currTime && isSessionBoundary(prevTime, currTime)) {
+			sessions.push(currentSession);
+			currentSession = [curr];
+		} else {
+			currentSession.push(curr);
+		}
+	}
+	sessions.push(currentSession);
+
+	// ── Pass 2: Cluster within sessions ───────────────────
+	const workUnits: CommitWorkUnit[] = [];
+
+	for (const session of sessions) {
+		// Parse all commits in session
+		const parsed = session.map((c) => parseConventionalCommit(c.message));
+		const modes = parsed.map((p, idx) =>
+			classifyWorkMode(p, session[idx].insertions, session[idx].deletions)
+		);
+
+		// Group by repo first, then by work mode within repo
+		const byRepo: Record<string, Array<{ commit: GitCommit; parsed: ParsedCommit; mode: CommitWorkMode }>> = {};
+		for (let idx = 0; idx < session.length; idx++) {
+			const repo = session[idx].repo || "unknown";
+			if (!byRepo[repo]) byRepo[repo] = [];
+			byRepo[repo].push({ commit: session[idx], parsed: parsed[idx], mode: modes[idx] });
+		}
+
+		// Within each repo, split by dominant work mode (debugging vs. building)
+		for (const [_repo, repoItems] of Object.entries(byRepo)) {
+			// Group by whether the mode is "debugging" or everything else
+			const debugItems = repoItems.filter((x) => x.mode === "debugging");
+			const buildItems = repoItems.filter((x) => x.mode !== "debugging");
+
+			const groups: typeof repoItems[] = [];
+			if (buildItems.length > 0) groups.push(buildItems);
+			if (debugItems.length > 0) groups.push(debugItems);
+
+			for (const group of groups) {
+				const groupCommits = group.map((x) => x.commit);
+				const groupParsed = group.map((x) => x.parsed);
+				const groupModes = group.map((x) => x.mode);
+
+				const workMode = dominantWorkMode(groupModes);
+				const allGeneric = groupCommits.every((c) => isGenericMessage(c.message));
+				const repos = [...new Set(groupCommits.map((c) => c.repo))];
+
+				// Collect why clauses
+				const whyClauses = groupCommits
+					.map((c) => extractWhyClause(c.message))
+					.filter((w): w is string => w !== null);
+
+				const times = groupCommits
+					.map((c) => c.time?.getTime())
+					.filter((t): t is number => t !== undefined && !isNaN(t));
+				const start = times.length > 0 ? new Date(Math.min(...times)) : new Date();
+				const end   = times.length > 0 ? new Date(Math.max(...times)) : new Date();
+
+				workUnits.push({
+					label: buildWorkUnitLabel(groupCommits, groupParsed, workMode),
+					workMode,
+					commits: groupCommits,
+					repos,
+					timeRange: { start, end },
+					hasWhyInformation: whyClauses.length > 0,
+					whyClause: whyClauses[0] ?? null,
+					isGeneric: allGeneric,
+				});
+			}
+		}
+	}
+
+	// Sort work units by start time (most recent first for rendering)
+	return workUnits.sort((a, b) => b.timeRange.start.getTime() - a.timeRange.start.getTime());
+}

--- a/src/analyze/knowledge.ts
+++ b/src/analyze/knowledge.ts
@@ -11,6 +11,8 @@
 
 import {
 	ArticleCluster,
+	ClaudeTaskSession,
+	CommitWorkUnit,
 	PatternAnalysis,
 	TemporalCluster,
 	RecurrenceSignal,
@@ -29,6 +31,10 @@ export interface KnowledgeSections {
 	tags: string[];
 	/** Article clusters produced by TF-IDF clustering of substantive browser visits. */
 	articleClusters?: ArticleCluster[];
+	/** Commit work units produced by the semantic extraction layer. */
+	commitWorkUnits?: CommitWorkUnit[];
+	/** Claude task sessions produced by the semantic extraction layer. */
+	claudeTaskSessions?: ClaudeTaskSession[];
 }
 
 export function generateKnowledgeSections(
@@ -43,6 +49,8 @@ export function generateKnowledgeSections(
 		recurrenceNotes: buildRecurrenceNotes(patterns.recurrenceSignals),
 		knowledgeDeltaLines: buildKnowledgeDeltaLines(patterns),
 		tags: generateTags(patterns),
+		commitWorkUnits: patterns.commitWorkUnits,
+		claudeTaskSessions: patterns.claudeTaskSessions,
 	};
 }
 

--- a/src/analyze/task-sessions.ts
+++ b/src/analyze/task-sessions.ts
@@ -1,0 +1,271 @@
+/**
+ * Task Session Analysis — Semantic Extraction Layer.
+ *
+ * Groups Claude Code conversations into higher-level ClaudeTaskSession objects,
+ * detects query chain SearchMissions, and (as a stub) fuses cross-source
+ * UnifiedTaskSession objects from all four data source types.
+ *
+ * No LLM calls. No network. No external libraries.
+ *
+ * Research basis:
+ *   - Barke, James, Polikarpova (OOPSLA 2023): acceleration/exploration bimodal model
+ *   - Hagen et al. (OAIR 2013): 10-minute query chain = single search mission
+ *   - Jones & Klinkner (WSDM 2008): file boundary = strongest session signal
+ *   - Broder (SIGIR Forum 2002): navigational/informational/transactional taxonomy
+ */
+
+import {
+	ClaudeSession,
+	ClaudeTaskSession,
+	ClaudeTaskType,
+	SearchMission,
+	SearchQuery,
+	BrowserVisit,
+	UnifiedTaskSession,
+	ArticleCluster,
+	CommitWorkUnit,
+} from "../types";
+import { classifyClaudeTaskType, CLAUDE_TOPIC_VOCABULARY } from "../filter/classify";
+import { extractTaskTitle } from "../collect/claude";
+
+// ── Claude Task Session Grouping ──────────────────────────
+
+/**
+ * Map ClaudeTaskType to the bimodal interaction mode.
+ * "acceleration" = user knows what they want, using AI to go faster.
+ * "exploration"  = user is discovering options or learning.
+ */
+function toInteractionMode(taskType: ClaudeTaskType): "acceleration" | "exploration" {
+	if (taskType === "learning" || taskType === "architecture") return "exploration";
+	return "acceleration";
+}
+
+/**
+ * Extract a vocabulary-based topic cluster label from prompt text.
+ * Falls back to the first 3 meaningful words when no vocabulary term matches.
+ */
+function extractTopicCluster(text: string): string {
+	for (const [pattern, label] of CLAUDE_TOPIC_VOCABULARY) {
+		if (pattern.test(text)) return label;
+	}
+	// Fallback: first 3 meaningful words
+	const words = text
+		.replace(/[^\w\s-]/g, " ")
+		.split(/\s+/)
+		.filter((w) => w.length > 3)
+		.slice(0, 3);
+	return words.length > 0 ? words.join(" ") : "general";
+}
+
+/**
+ * Group flat ClaudeSession[] into ClaudeTaskSession[] objects, where each
+ * session corresponds to one JSONL file (conversation identity boundary).
+ *
+ * Algorithm:
+ *   1. Group all ClaudeSession objects by their `conversationFile` field.
+ *   2. For each file group, find the opener (isConversationOpener === true).
+ *   3. Extract task title and classify task type from the opener.
+ *   4. Build a ClaudeTaskSession from the group.
+ *
+ * @param sessions  All ClaudeSession objects for the day (may include non-openers).
+ */
+export function groupClaudeSessionsIntoTasks(sessions: ClaudeSession[]): ClaudeTaskSession[] {
+	if (sessions.length === 0) return [];
+
+	// Group by conversation file
+	const byFile = new Map<string, ClaudeSession[]>();
+	for (const s of sessions) {
+		const file = s.conversationFile || "unknown";
+		const existing = byFile.get(file);
+		if (existing) {
+			existing.push(s);
+		} else {
+			byFile.set(file, [s]);
+		}
+	}
+
+	const taskSessions: ClaudeTaskSession[] = [];
+
+	for (const [conversationFile, prompts] of byFile) {
+		// Sort within conversation by time (oldest first)
+		const sorted = [...prompts].sort((a, b) => a.time.getTime() - b.time.getTime());
+
+		// Find the opener — if none is marked as opener, treat the earliest as opener
+		const opener = sorted.find((s) => s.isConversationOpener) ?? sorted[0];
+
+		const taskTitle = extractTaskTitle(opener.prompt);
+		const taskType = classifyClaudeTaskType(opener.prompt);
+		const topicCluster = extractTopicCluster(opener.prompt);
+		const interactionMode = toInteractionMode(taskType);
+		const turnCount = opener.conversationTurnCount || sorted.length;
+
+		// A session is "deep learning" if it has 5+ turns on a conceptual topic
+		const isDeepLearning = turnCount >= 5 &&
+			(taskType === "learning" || taskType === "architecture");
+
+		const times = sorted.map((s) => s.time.getTime());
+		const start = new Date(Math.min(...times));
+		const end   = new Date(Math.max(...times));
+
+		taskSessions.push({
+			taskTitle,
+			taskType,
+			topicCluster,
+			prompts: sorted,
+			timeRange: { start, end },
+			project: opener.project,
+			conversationFile,
+			turnCount,
+			interactionMode,
+			isDeepLearning,
+		});
+	}
+
+	// Sort by start time (most recent first)
+	return taskSessions.sort((a, b) => b.timeRange.start.getTime() - a.timeRange.start.getTime());
+}
+
+// ── Search Mission Detection ──────────────────────────────
+
+/** Broder query intent classification patterns. */
+const NAV_QUERY_RE = /\b(site:|docs|github|npm|official|login|sign\s+in|download)\b/i;
+const INFO_QUERY_RE = /^(how|what|why|when|where|who|which|can|is|does|difference\s+between|vs\.?|versus|explain)/i;
+
+function classifySearchIntent(query: string): "navigational" | "informational" | "transactional" {
+	if (NAV_QUERY_RE.test(query)) return "navigational";
+	if (INFO_QUERY_RE.test(query)) return "informational";
+	return "transactional";
+}
+
+/**
+ * Extract content words from a search query for chain overlap detection.
+ * Filters out stopwords and words shorter than 3 characters.
+ */
+function queryContentWords(query: string): Set<string> {
+	const QUERY_STOPWORDS = new Set([
+		"the", "and", "for", "are", "but", "not", "you", "all", "can",
+		"was", "will", "had", "has", "is", "it", "its", "of", "to",
+		"in", "on", "at", "an", "a", "be", "do",
+	]);
+	const words = query
+		.toLowerCase()
+		.replace(/[^\w\s]/g, " ")
+		.split(/\s+/)
+		.filter((w) => w.length > 2 && !QUERY_STOPWORDS.has(w));
+	return new Set(words);
+}
+
+/**
+ * Check whether two queries share at least one content word.
+ */
+function sharesContentWord(a: Set<string>, b: Set<string>): boolean {
+	for (const w of a) {
+		if (b.has(w)) return true;
+	}
+	return false;
+}
+
+/**
+ * Detect search missions from a list of queries and nearby browser visits.
+ *
+ * A search mission = consecutive queries within `window` ms that share at
+ * least one content word (Hagen et al. OAIR 2013 definition).
+ *
+ * @param searches  All search queries for the day.
+ * @param visits    All browser visits (used to find visits within the mission window).
+ * @param window    Max milliseconds between queries to chain them (default: 10 min).
+ */
+export function detectSearchMissions(
+	searches: SearchQuery[],
+	visits: BrowserVisit[],
+	window = 10 * 60 * 1000,
+): SearchMission[] {
+	if (searches.length === 0) return [];
+
+	// Sort chronologically
+	const sorted = [...searches].sort((a, b) => {
+		return (a.time?.getTime() ?? 0) - (b.time?.getTime() ?? 0);
+	});
+
+	const missions: SearchMission[] = [];
+	let chainStart = 0;
+
+	while (chainStart < sorted.length) {
+		let chainEnd = chainStart;
+		const startWords = queryContentWords(sorted[chainStart].query);
+
+		// Extend chain as long as queries are within `window` ms AND share a content word
+		while (chainEnd + 1 < sorted.length) {
+			const curr = sorted[chainEnd];
+			const next = sorted[chainEnd + 1];
+			const currTime = curr.time?.getTime() ?? 0;
+			const nextTime = next.time?.getTime() ?? 0;
+
+			if (nextTime - currTime > window) break;
+
+			// Check content word overlap between the chain opener and the next query
+			const nextWords = queryContentWords(next.query);
+			if (!sharesContentWord(startWords, nextWords)) break;
+
+			chainEnd++;
+		}
+
+		const chainQueries = sorted.slice(chainStart, chainEnd + 1);
+
+		// Find visits within the mission time window
+		const missionStart = chainQueries[0].time?.getTime() ?? 0;
+		const missionEnd   = (chainQueries[chainEnd - chainStart].time?.getTime() ?? missionStart) + window;
+		const missionVisits = visits.filter((v) => {
+			const vt = v.time?.getTime();
+			return vt !== undefined && vt >= missionStart && vt <= missionEnd;
+		});
+
+		const intentType = classifySearchIntent(chainQueries[0].query);
+
+		missions.push({
+			label: chainQueries[0].query,
+			queries: chainQueries,
+			visits: missionVisits,
+			timeRange: {
+				start: chainQueries[0].time ?? new Date(missionStart),
+				end: chainQueries[chainEnd - chainStart].time ?? new Date(missionEnd),
+			},
+			intentType,
+		});
+
+		chainStart = chainEnd + 1;
+	}
+
+	// Only return multi-query missions (singletons are not really "missions")
+	// Actually per design we keep all missions including single queries
+	return missions;
+}
+
+// ── Cross-Source Fusion ───────────────────────────────────
+
+/**
+ * Fuse work units from all four sources into UnifiedTaskSession objects
+ * using temporal overlap + topic entity overlap.
+ *
+ * TODO: This is currently a stub returning []. The full fusion algorithm
+ * (Section "Cross-Source Fusion" in design-semantic-extraction-layer.md)
+ * requires topic entity extraction from each source type and a time-window
+ * merge pass. Implement in a follow-up once the per-source work units
+ * have been validated in production.
+ *
+ * @param _browser   Article clusters from browser reading
+ * @param _commits   Commit work units from git history
+ * @param _claude    Claude task sessions from AI interactions
+ * @param _search    Search missions from query chains
+ */
+export function fuseCrossSourceSessions(
+	_browser: ArticleCluster[],
+	_commits: CommitWorkUnit[],
+	_claude: ClaudeTaskSession[],
+	_search: SearchMission[],
+): UnifiedTaskSession[] {
+	// TODO: Implement temporal + topic entity overlap fusion.
+	// This stub returns [] so the rest of the pipeline can ship while fusion
+	// is designed and validated.
+	return [];
+}

--- a/src/filter/classify.ts
+++ b/src/filter/classify.ts
@@ -1,5 +1,6 @@
 import {
 	ActivityType,
+	ClaudeTaskType,
 	IntentType,
 	StructuredEvent,
 	ClassificationResult,
@@ -10,6 +11,9 @@ import {
 	GitCommit,
 	CategorizedVisits,
 } from "../types";
+
+// Re-export ClaudeTaskType so existing imports of it from classify.ts keep working.
+export type { ClaudeTaskType };
 import { callLocal } from "../summarize/ai-client";
 import { categorizeDomain } from "./categorize";
 import * as log from "../plugin/log";
@@ -137,22 +141,6 @@ function normalizeGitCommits(commits: GitCommit[]): RawEvent[] {
 }
 
 // ── Claude Task Classification ──────────────────────────
-
-/**
- * Vocabulary-based intent type for Claude Code conversations.
- * Applied to the opener prompt (first user message in a JSONL file).
- *   - "implementation"  Add/Build/Create/Implement/Write — acceleration mode
- *   - "debugging"       Fix/Debug/Why does/not working/error — acceleration
- *   - "review"          Review/Check/Audit/Is this correct — acceleration
- *   - "learning"        Explain/Describe/What is/How does — exploration
- *   - "architecture"    Design/Plan/Should I/What approach — exploration
- */
-export type ClaudeTaskType =
-	| "implementation"
-	| "debugging"
-	| "review"
-	| "learning"
-	| "architecture";
 
 /**
  * Ordered decision tree: first matching pattern wins.

--- a/src/render/merge.ts
+++ b/src/render/merge.ts
@@ -14,11 +14,17 @@
 
 // ── Known generated section headings ─────────────────────
 // Any `## ` heading NOT in this set is treated as user-added content.
+// Emoji-stripping in stripEmoji() removes leading emoji before matching,
+// so these entries are stored without their emoji prefixes.
 const GENERATED_HEADINGS = new Set([
 	"Notable",
 	"Cognitive Patterns",
 	"Knowledge Insights",
 	"Searches",
+	"Today I Read About",
+	"Today I Worked On",
+	"Today I Asked Claude About",
+	"Task Sessions",
 	"Claude Code / AI Work",
 	"Browser Activity",
 	"Git Activity",

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -331,6 +331,66 @@ export function renderMarkdown(
 		lines.push("");
 	}
 
+	// ── Today I Worked On (commit work units) ────
+	if (knowledge?.commitWorkUnits && knowledge.commitWorkUnits.length > 0) {
+		lines.push("> [!info]- \u{1F528} Today I Worked On");
+		for (const unit of knowledge.commitWorkUnits) {
+			if (unit.isGeneric) continue; // skip low-signal WIP units
+			const commitWord = unit.commits.length === 1 ? "commit" : "commits";
+			const insertions = unit.commits.reduce((sum, c) => sum + c.insertions, 0);
+			const deletions = unit.commits.reduce((sum, c) => sum + c.deletions, 0);
+			const stats = insertions > 0 || deletions > 0
+				? `, ${insertions} insertions`
+				: "";
+			lines.push(`> - **${escapeForMarkdown(unit.label)}** \u2014 ${unit.commits.length} ${commitWord}${stats}`);
+			if (unit.hasWhyInformation && unit.whyClause) {
+				lines.push(`>   *${escapeForMarkdown(unit.whyClause)}*`);
+			} else if (unit.commits.length > 0) {
+				// Show the most descriptive commit message as a sub-line
+				const best = unit.commits.reduce((a, b) =>
+					b.message.length > a.message.length ? b : a
+				);
+				if (best.message && !unit.label.toLowerCase().includes(best.message.slice(0, 20).toLowerCase())) {
+					lines.push(`>   _${escapeForMarkdown(best.message.slice(0, 120))}_`);
+				}
+			}
+		}
+		lines.push("");
+	}
+
+	// ── Today I Asked Claude About (task sessions) ────
+	if (knowledge?.claudeTaskSessions && knowledge.claudeTaskSessions.length > 0) {
+		lines.push("> [!info]- \u{1F916} Today I Asked Claude About");
+		for (const session of knowledge.claudeTaskSessions) {
+			const turnWord = session.turnCount === 1 ? "turn" : "turns";
+			const depthLabel = session.isDeepLearning ? "deep exploration"
+				: session.interactionMode === "exploration" ? "exploration"
+				: "implementation";
+			const topicBadge = session.topicCluster !== "general"
+				? ` \u2014 \`${session.topicCluster}\`` : "";
+			lines.push(
+				`> - **${escapeForMarkdown(session.taskTitle)}**${topicBadge} ` +
+				`_(${session.taskType}, ${session.turnCount} ${turnWord}, ${depthLabel})_`
+			);
+		}
+		lines.push("");
+	}
+
+	// ── Task Sessions (cross-source unified sessions) ────
+	// Only rendered when cross-source fusion has produced results.
+	// The fusion stub in task-sessions.ts returns [] so this section
+	// is currently suppressed. It will activate once fusion is implemented.
+	if (knowledge?.commitWorkUnits || knowledge?.claudeTaskSessions) {
+		// Placeholder: Task Sessions section is reserved for cross-source fusion output.
+		// When unifiedTaskSessions are available they will be rendered here as:
+		//   ## 🔗 Task Sessions
+		//   **HH:MM – HH:MM · <label>**
+		//   _lifecycle stages_
+		//   - Read: <articles>
+		//   - Asked Claude: <prompts>
+		//   - Committed: <commits>
+	}
+
 	// ── Claude Code sessions ─────────────────────
 	if (claudeSessions.length) {
 		lines.push("## \u{1F916} Claude Code / AI Work");

--- a/tests/integration/privacy-escalation.test.ts
+++ b/tests/integration/privacy-escalation.test.ts
@@ -50,6 +50,8 @@ const patterns: PatternAnalysis = {
 	activityConcentrationScore: 1.0,
 	topActivityTypes: [{ type: "research", count: 3, pct: 100 }],
 	peakHours: [{ hour: 10, count: 3 }],
+	commitWorkUnits: [],
+	claudeTaskSessions: [],
 };
 
 describe("privacy escalation chain", () => {

--- a/tests/unit/analyze/commits.test.ts
+++ b/tests/unit/analyze/commits.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from "vitest";
+import {
+	parseConventionalCommit,
+	classifyWorkMode,
+	groupCommitsIntoWorkUnits,
+} from "../../../src/analyze/commits";
+import { GitCommit } from "../../../src/types";
+
+// ── Helpers ───────────────────────────────────────────────
+
+const BASE_MS = 1_700_000_000_000;
+const MIN = 60_000;
+
+function makeCommit(
+	message: string,
+	offsetMin = 0,
+	repo = "my-repo",
+	insertions = 10,
+	deletions = 2,
+): GitCommit {
+	return {
+		hash: `hash-${offsetMin}`,
+		message,
+		time: new Date(BASE_MS + offsetMin * MIN),
+		repo,
+		filesChanged: 1,
+		insertions,
+		deletions,
+	};
+}
+
+// ── parseConventionalCommit ───────────────────────────────
+
+describe("parseConventionalCommit", () => {
+	it("parses a simple feat commit", () => {
+		const result = parseConventionalCommit("feat: add login page");
+		expect(result.type).toBe("feat");
+		expect(result.scope).toBeNull();
+		expect(result.breaking).toBe(false);
+		expect(result.description).toBe("add login page");
+	});
+
+	it("parses a commit with scope", () => {
+		const result = parseConventionalCommit("fix(render): fix null pointer");
+		expect(result.type).toBe("fix");
+		expect(result.scope).toBe("render");
+		expect(result.description).toBe("fix null pointer");
+	});
+
+	it("parses a breaking change commit", () => {
+		const result = parseConventionalCommit("feat(api)!: change response format");
+		expect(result.type).toBe("feat");
+		expect(result.scope).toBe("api");
+		expect(result.breaking).toBe(true);
+		expect(result.description).toBe("change response format");
+	});
+
+	it("handles non-conventional commit", () => {
+		const result = parseConventionalCommit("update some things");
+		expect(result.type).toBe("");
+		expect(result.scope).toBeNull();
+		expect(result.breaking).toBe(false);
+		expect(result.description).toBe("update some things");
+		expect(result.raw).toBe("update some things");
+	});
+
+	it("is case-insensitive for type", () => {
+		const result = parseConventionalCommit("FEAT: add something");
+		expect(result.type).toBe("feat");
+	});
+
+	it("preserves raw message exactly", () => {
+		const msg = "feat(scope): description with | pipe";
+		const result = parseConventionalCommit(msg);
+		expect(result.raw).toBe(msg);
+	});
+
+	it("handles description with pipe characters", () => {
+		const result = parseConventionalCommit("docs: update README | add examples");
+		expect(result.type).toBe("docs");
+		expect(result.description).toBe("update README | add examples");
+	});
+});
+
+// ── classifyWorkMode ──────────────────────────────────────
+
+describe("classifyWorkMode", () => {
+	it("maps feat type to building", () => {
+		const parsed = parseConventionalCommit("feat: add feature");
+		expect(classifyWorkMode(parsed, 100, 10)).toBe("building");
+	});
+
+	it("maps fix type to debugging", () => {
+		const parsed = parseConventionalCommit("fix: resolve crash");
+		expect(classifyWorkMode(parsed, 5, 5)).toBe("debugging");
+	});
+
+	it("maps refactor to restructuring", () => {
+		const parsed = parseConventionalCommit("refactor: extract helper");
+		expect(classifyWorkMode(parsed, 20, 20)).toBe("restructuring");
+	});
+
+	it("maps test type to testing", () => {
+		const parsed = parseConventionalCommit("test: add unit tests");
+		expect(classifyWorkMode(parsed, 50, 0)).toBe("testing");
+	});
+
+	it("maps docs type to documenting", () => {
+		const parsed = parseConventionalCommit("docs: update README");
+		expect(classifyWorkMode(parsed, 10, 5)).toBe("documenting");
+	});
+
+	it("maps chore/build/ci to infrastructure", () => {
+		const c = parseConventionalCommit("chore: update deps");
+		expect(classifyWorkMode(c, 5, 5)).toBe("infrastructure");
+		const b = parseConventionalCommit("build: upgrade webpack");
+		expect(classifyWorkMode(b, 5, 5)).toBe("infrastructure");
+		const ci = parseConventionalCommit("ci: fix pipeline");
+		expect(classifyWorkMode(ci, 5, 5)).toBe("infrastructure");
+	});
+
+	it("maps perf to optimizing", () => {
+		const parsed = parseConventionalCommit("perf: cache results");
+		expect(classifyWorkMode(parsed, 20, 5)).toBe("optimizing");
+	});
+
+	it("maps revert to reverting", () => {
+		const parsed = parseConventionalCommit("revert: undo previous change");
+		expect(classifyWorkMode(parsed, 0, 50)).toBe("reverting");
+	});
+
+	it("uses keyword fallback for bug-fix language", () => {
+		const parsed = parseConventionalCommit("fixed null pointer exception");
+		expect(classifyWorkMode(parsed, 3, 3)).toBe("debugging");
+	});
+
+	it("uses keyword fallback for add/implement language", () => {
+		const parsed = parseConventionalCommit("implement new auth flow");
+		expect(classifyWorkMode(parsed, 80, 5)).toBe("building");
+	});
+
+	it("uses ratio heuristic when only insertions", () => {
+		const parsed = parseConventionalCommit("some new stuff");
+		expect(classifyWorkMode(parsed, 100, 0)).toBe("building");
+	});
+
+	it("uses ratio heuristic for deletions-heavy change", () => {
+		const parsed = parseConventionalCommit("remove old code");
+		expect(classifyWorkMode(parsed, 2, 100)).toBe("restructuring");
+	});
+
+	it("falls back to tweaking for generic messages", () => {
+		const parsed = parseConventionalCommit("misc");
+		expect(classifyWorkMode(parsed, 2, 2)).toBe("tweaking");
+	});
+});
+
+// ── groupCommitsIntoWorkUnits ─────────────────────────────
+
+describe("groupCommitsIntoWorkUnits", () => {
+	it("returns [] for empty input", () => {
+		expect(groupCommitsIntoWorkUnits([])).toEqual([]);
+	});
+
+	it("groups a single commit into one work unit", () => {
+		const commits = [makeCommit("feat: add login page", 0)];
+		const units = groupCommitsIntoWorkUnits(commits);
+		expect(units).toHaveLength(1);
+		expect(units[0].commits).toHaveLength(1);
+	});
+
+	it("groups nearby commits into one session", () => {
+		const commits = [
+			makeCommit("feat: add header", 0),
+			makeCommit("feat: add footer", 30), // 30 min gap — within 90 min session
+		];
+		const units = groupCommitsIntoWorkUnits(commits);
+		// Both are feat building — should be one unit
+		const buildingUnits = units.filter((u) => u.workMode === "building");
+		expect(buildingUnits.length).toBeGreaterThanOrEqual(1);
+		const totalCommits = units.reduce((s, u) => s + u.commits.length, 0);
+		expect(totalCommits).toBe(2);
+	});
+
+	it("splits sessions on a 90+ minute gap", () => {
+		const commits = [
+			makeCommit("feat: morning work", 0),
+			makeCommit("fix: afternoon fix", 100), // 100 min gap — new session
+		];
+		const units = groupCommitsIntoWorkUnits(commits);
+		// Should produce 2 separate work units (different sessions)
+		expect(units.length).toBe(2);
+	});
+
+	it("separates debugging commits from building commits within a session", () => {
+		const commits = [
+			makeCommit("feat: add feature", 0),
+			makeCommit("fix: fix crash", 10),   // 10 min gap, same session
+		];
+		const units = groupCommitsIntoWorkUnits(commits);
+		// Should produce 2 units: one building, one debugging
+		const modes = units.map((u) => u.workMode);
+		expect(modes).toContain("building");
+		expect(modes).toContain("debugging");
+	});
+
+	it("uses scope to label work units", () => {
+		const commits = [
+			makeCommit("feat(render): add section", 0),
+			makeCommit("fix(render): fix null check", 5),
+		];
+		const units = groupCommitsIntoWorkUnits(commits);
+		// The building unit should be labeled with scope "render"
+		const buildUnit = units.find((u) => u.workMode === "building");
+		expect(buildUnit?.label).toContain("render");
+	});
+
+	it("populates timeRange from commit times", () => {
+		const start = new Date(BASE_MS);
+		const end = new Date(BASE_MS + 30 * MIN);
+		const commits = [
+			makeCommit("feat: first", 0),
+			makeCommit("feat: second", 30),
+		];
+		const units = groupCommitsIntoWorkUnits(commits);
+		const unit = units.find((u) => u.commits.length > 0);
+		expect(unit).toBeDefined();
+		if (unit) {
+			expect(unit.timeRange.start.getTime()).toBeLessThanOrEqual(end.getTime());
+			expect(unit.timeRange.end.getTime()).toBeGreaterThanOrEqual(start.getTime());
+		}
+	});
+
+	it("detects why information in commit messages", () => {
+		const commits = [makeCommit("feat: add caching because it was slow", 0)];
+		const units = groupCommitsIntoWorkUnits(commits);
+		expect(units[0].hasWhyInformation).toBe(true);
+		expect(units[0].whyClause).not.toBeNull();
+	});
+
+	it("marks generic commits with isGeneric=true", () => {
+		const commits = [makeCommit("wip", 0)];
+		const units = groupCommitsIntoWorkUnits(commits);
+		expect(units[0].isGeneric).toBe(true);
+	});
+
+	it("populates repos from commit data", () => {
+		const commits = [makeCommit("feat: add feature", 0, "my-repo")];
+		const units = groupCommitsIntoWorkUnits(commits);
+		expect(units[0].repos).toContain("my-repo");
+	});
+
+	it("handles commits without timestamps gracefully", () => {
+		const commit: GitCommit = {
+			hash: "abc",
+			message: "feat: something",
+			time: null,
+			repo: "repo",
+			filesChanged: 1,
+			insertions: 5,
+			deletions: 0,
+		};
+		const units = groupCommitsIntoWorkUnits([commit]);
+		expect(units).toHaveLength(1);
+	});
+
+	it("sorts work units most-recent first", () => {
+		const commits = [
+			makeCommit("feat: older", 0),
+			makeCommit("feat: newer", 200), // new session
+		];
+		const units = groupCommitsIntoWorkUnits(commits);
+		if (units.length >= 2) {
+			expect(units[0].timeRange.start.getTime()).toBeGreaterThanOrEqual(
+				units[1].timeRange.start.getTime()
+			);
+		}
+	});
+});

--- a/tests/unit/analyze/knowledge.test.ts
+++ b/tests/unit/analyze/knowledge.test.ts
@@ -25,6 +25,8 @@ function makePatterns(overrides: Partial<PatternAnalysis> = {}): PatternAnalysis
 			{ hour: 10, count: 8 },
 			{ hour: 14, count: 6 },
 		],
+		commitWorkUnits: [],
+		claudeTaskSessions: [],
 		...overrides,
 	};
 }

--- a/tests/unit/analyze/task-sessions.test.ts
+++ b/tests/unit/analyze/task-sessions.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from "vitest";
+import {
+	groupClaudeSessionsIntoTasks,
+	detectSearchMissions,
+	fuseCrossSourceSessions,
+} from "../../../src/analyze/task-sessions";
+import { ClaudeSession, SearchQuery } from "../../../src/types";
+
+// ── Helpers ───────────────────────────────────────────────
+
+const BASE_MS = 1_700_000_000_000;
+const MIN = 60_000;
+
+function makeSession(
+	prompt: string,
+	offsetMin = 0,
+	file = "conv1.jsonl",
+	project = "my-project",
+	isOpener = true,
+	turnCount = 1,
+): ClaudeSession {
+	return {
+		prompt,
+		time: new Date(BASE_MS + offsetMin * MIN),
+		project,
+		isConversationOpener: isOpener,
+		conversationFile: file,
+		conversationTurnCount: turnCount,
+	};
+}
+
+function makeSearch(query: string, offsetMin = 0): SearchQuery {
+	return {
+		query,
+		time: new Date(BASE_MS + offsetMin * MIN),
+		engine: "google.com",
+	};
+}
+
+// ── groupClaudeSessionsIntoTasks ─────────────────────────
+
+describe("groupClaudeSessionsIntoTasks", () => {
+	it("returns [] for empty input", () => {
+		expect(groupClaudeSessionsIntoTasks([])).toEqual([]);
+	});
+
+	it("groups sessions by conversationFile", () => {
+		const sessions = [
+			makeSession("fix the login bug", 0, "conv1.jsonl", "proj", true, 2),
+			makeSession("also check the session timeout", 5, "conv1.jsonl", "proj", false, 2),
+			makeSession("explain typescript generics", 60, "conv2.jsonl", "proj", true, 1),
+		];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks).toHaveLength(2);
+		const conv1 = tasks.find((t) => t.conversationFile === "conv1.jsonl");
+		const conv2 = tasks.find((t) => t.conversationFile === "conv2.jsonl");
+		expect(conv1?.prompts).toHaveLength(2);
+		expect(conv2?.prompts).toHaveLength(1);
+	});
+
+	it("extracts task title from opener prompt", () => {
+		const sessions = [makeSession("implement user authentication middleware", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].taskTitle.length).toBeGreaterThan(0);
+		// Title should strip the "implement" verb prefix
+		expect(tasks[0].taskTitle.toLowerCase()).not.toMatch(/^implement\s/);
+	});
+
+	it("classifies debugging tasks correctly", () => {
+		const sessions = [makeSession("fix the broken import that throws TypeError", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].taskType).toBe("debugging");
+	});
+
+	it("classifies learning tasks correctly", () => {
+		const sessions = [makeSession("explain how typescript generic constraints work", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].taskType).toBe("learning");
+	});
+
+	it("classifies architecture tasks correctly", () => {
+		const sessions = [makeSession("design a state management architecture for my app", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].taskType).toBe("architecture");
+	});
+
+	it("classifies implementation tasks by default", () => {
+		const sessions = [makeSession("create a new authentication service", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].taskType).toBe("implementation");
+	});
+
+	it("sets interactionMode to exploration for learning tasks", () => {
+		const sessions = [makeSession("explain how rust borrow checker works", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].interactionMode).toBe("exploration");
+	});
+
+	it("sets interactionMode to acceleration for debugging tasks", () => {
+		const sessions = [makeSession("fix the null error in user service", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].interactionMode).toBe("acceleration");
+	});
+
+	it("detects deep learning when turnCount >= 5 on learning task", () => {
+		const sessions = [
+			makeSession("explain how event loops work in javascript", 0, "deep.jsonl", "p", true, 7),
+			makeSession("follow up question 1", 5, "deep.jsonl", "p", false, 7),
+			makeSession("follow up question 2", 10, "deep.jsonl", "p", false, 7),
+		];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		const task = tasks[0];
+		expect(task.turnCount).toBe(7);
+		expect(task.isDeepLearning).toBe(true);
+	});
+
+	it("does not mark implementation as deep learning even with 5+ turns", () => {
+		const sessions = [makeSession("implement a user service", 0, "impl.jsonl", "p", true, 10)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].isDeepLearning).toBe(false);
+	});
+
+	it("extracts topic cluster from prompt vocabulary", () => {
+		const sessions = [makeSession("fix the typescript interface that causes type error", 0)];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		// Should match "typescript" in CLAUDE_TOPIC_VOCABULARY
+		expect(tasks[0].topicCluster).toBe("typescript");
+	});
+
+	it("computes timeRange from prompt times", () => {
+		const sessions = [
+			makeSession("ask first question", 0, "f.jsonl", "p", true, 3),
+			makeSession("ask second question", 10, "f.jsonl", "p", false, 3),
+			makeSession("ask third question", 20, "f.jsonl", "p", false, 3),
+		];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].timeRange.start.getTime()).toBe(BASE_MS);
+		expect(tasks[0].timeRange.end.getTime()).toBe(BASE_MS + 20 * MIN);
+	});
+
+	it("sorts tasks by start time (most recent first)", () => {
+		const sessions = [
+			makeSession("older conversation", 0, "old.jsonl", "p"),
+			makeSession("newer conversation", 120, "new.jsonl", "p"),
+		];
+		const tasks = groupClaudeSessionsIntoTasks(sessions);
+		expect(tasks[0].timeRange.start.getTime()).toBeGreaterThan(
+			tasks[1].timeRange.start.getTime()
+		);
+	});
+
+	it("handles sessions with unknown conversation file gracefully", () => {
+		const session: ClaudeSession = {
+			prompt: "fix the bug",
+			time: new Date(BASE_MS),
+			project: "proj",
+			isConversationOpener: true,
+			conversationFile: "",
+			conversationTurnCount: 1,
+		};
+		const tasks = groupClaudeSessionsIntoTasks([session]);
+		expect(tasks).toHaveLength(1);
+	});
+});
+
+// ── detectSearchMissions ─────────────────────────────────
+
+describe("detectSearchMissions", () => {
+	it("returns [] for empty searches", () => {
+		expect(detectSearchMissions([], [])).toEqual([]);
+	});
+
+	it("treats a single search as a single mission", () => {
+		const searches = [makeSearch("typescript generics tutorial", 0)];
+		const missions = detectSearchMissions(searches, []);
+		expect(missions).toHaveLength(1);
+		expect(missions[0].label).toBe("typescript generics tutorial");
+	});
+
+	it("chains queries within 10 minutes with shared content word", () => {
+		const searches = [
+			makeSearch("typescript generics", 0),
+			makeSearch("typescript generic extends", 5),  // shares "typescript" and "generic"
+			makeSearch("typescript generic constraints", 9), // shares "typescript"
+		];
+		const missions = detectSearchMissions(searches, []);
+		// All three should chain into one mission
+		expect(missions).toHaveLength(1);
+		expect(missions[0].queries).toHaveLength(3);
+	});
+
+	it("breaks chain when time gap exceeds 10 minutes", () => {
+		const searches = [
+			makeSearch("typescript generics", 0),
+			makeSearch("typescript types", 15),  // 15 min gap — breaks chain
+		];
+		const missions = detectSearchMissions(searches, [], 10 * MIN);
+		expect(missions).toHaveLength(2);
+	});
+
+	it("breaks chain when queries share no content words", () => {
+		const searches = [
+			makeSearch("typescript generics tutorial", 0),
+			makeSearch("pizza recipe dinner", 3),  // no shared words, within 10 min
+		];
+		const missions = detectSearchMissions(searches, [], 10 * MIN);
+		expect(missions).toHaveLength(2);
+	});
+
+	it("uses first query as mission label", () => {
+		const searches = [
+			makeSearch("how does jwt work", 0),
+			makeSearch("how jwt authentication flow works", 5),
+		];
+		const missions = detectSearchMissions(searches, [], 10 * MIN);
+		expect(missions[0].label).toBe("how does jwt work");
+	});
+
+	it("classifies informational queries correctly", () => {
+		const searches = [makeSearch("how does typescript inference work", 0)];
+		const missions = detectSearchMissions(searches, []);
+		expect(missions[0].intentType).toBe("informational");
+	});
+
+	it("classifies navigational queries correctly", () => {
+		const searches = [makeSearch("typescript docs github", 0)];
+		const missions = detectSearchMissions(searches, []);
+		expect(missions[0].intentType).toBe("navigational");
+	});
+
+	it("classifies transactional queries as default", () => {
+		// "best typescript books" has no navigational or informational markers
+		const searches = [makeSearch("best typescript books 2024", 0)];
+		const missions = detectSearchMissions(searches, []);
+		expect(missions[0].intentType).toBe("transactional");
+	});
+
+	it("respects custom window parameter", () => {
+		const searches = [
+			makeSearch("typescript generics", 0),
+			makeSearch("typescript types", 3),  // 3 min gap
+		];
+		// With 2-minute window, the 3-minute gap breaks the chain
+		const missions = detectSearchMissions(searches, [], 2 * MIN);
+		expect(missions).toHaveLength(2);
+	});
+
+	it("sets timeRange from query times", () => {
+		const searches = [makeSearch("react hooks", 0)];
+		const missions = detectSearchMissions(searches, []);
+		expect(missions[0].timeRange.start.getTime()).toBe(BASE_MS);
+	});
+});
+
+// ── fuseCrossSourceSessions ──────────────────────────────
+
+describe("fuseCrossSourceSessions", () => {
+	it("returns [] (stub implementation)", () => {
+		const result = fuseCrossSourceSessions([], [], [], []);
+		expect(result).toEqual([]);
+	});
+});

--- a/tests/unit/collect/git.test.ts
+++ b/tests/unit/collect/git.test.ts
@@ -3,15 +3,30 @@ import { readGitHistory, parseGitLogOutput } from "../../../src/collect/git";
 import type { DailyDigestSettings } from "../../../src/settings/types";
 
 // ── parseGitLogOutput tests ─────────────────────────────
+//
+// The --numstat format produces per-commit output structured as:
+//   <hash>|<refs>|<subject>|<authorDateISO>
+//   (blank line)
+//   <insertions>\t<deletions>\t<filepath>
+//   ...
+//   (blank line separating commits)
+//
+// The %D (refs) field may be empty string. Subject may contain "|".
 
 describe("parseGitLogOutput", () => {
-	it("parses well-formed git log output", () => {
+	it("parses well-formed numstat git log output", () => {
+		// Two commits with numstat file lines
 		const raw = [
-			"abc1234|feat: Add OAuth PKCE flow|2026-02-20T14:30:00+00:00",
-			" 3 files changed, 42 insertions(+), 8 deletions(-)",
+			"abc1234||feat: Add OAuth PKCE flow|2026-02-20T14:30:00+00:00",
 			"",
-			"def5678|fix: Handle null token edge case|2026-02-20T15:15:00+00:00",
-			" 1 file changed, 12 insertions(+), 3 deletions(-)",
+			"42\t8\tsrc/auth/pkce.ts",
+			"5\t0\tsrc/auth/index.ts",
+			"3\t2\ttests/auth.test.ts",
+			"",
+			"def5678||fix: Handle null token edge case|2026-02-20T15:15:00+00:00",
+			"",
+			"12\t3\tsrc/auth/token.ts",
+			"",
 		].join("\n");
 
 		const commits = parseGitLogOutput(raw, "my-repo");
@@ -22,19 +37,26 @@ describe("parseGitLogOutput", () => {
 		expect(commits[0].time).toBeInstanceOf(Date);
 		expect(commits[0].repo).toBe("my-repo");
 		expect(commits[0].filesChanged).toBe(3);
-		expect(commits[0].insertions).toBe(42);
-		expect(commits[0].deletions).toBe(8);
+		expect(commits[0].insertions).toBe(50); // 42 + 5 + 3
+		expect(commits[0].deletions).toBe(10);  // 8 + 0 + 2
+		expect(commits[0].filePaths).toEqual([
+			"src/auth/pkce.ts",
+			"src/auth/index.ts",
+			"tests/auth.test.ts",
+		]);
 
 		expect(commits[1].hash).toBe("def5678");
 		expect(commits[1].filesChanged).toBe(1);
 		expect(commits[1].insertions).toBe(12);
 		expect(commits[1].deletions).toBe(3);
+		expect(commits[1].filePaths).toEqual(["src/auth/token.ts"]);
 	});
 
-	it("handles insertions-only stat lines", () => {
+	it("handles insertions-only numstat lines", () => {
 		const raw = [
-			"aaa1111|feat: Add new file|2026-02-20T10:00:00+00:00",
-			" 1 file changed, 20 insertions(+)",
+			"aaa1111||feat: Add new file|2026-02-20T10:00:00+00:00",
+			"",
+			"20\t0\tsrc/newfile.ts",
 		].join("\n");
 
 		const commits = parseGitLogOutput(raw, "repo");
@@ -42,23 +64,28 @@ describe("parseGitLogOutput", () => {
 		expect(commits[0].deletions).toBe(0);
 	});
 
-	it("handles deletions-only stat lines", () => {
+	it("handles deletions-only numstat lines", () => {
 		const raw = [
-			"bbb2222|chore: Remove dead code|2026-02-20T10:00:00+00:00",
-			" 2 files changed, 15 deletions(-)",
+			"bbb2222||chore: Remove dead code|2026-02-20T10:00:00+00:00",
+			"",
+			"0\t15\tsrc/old.ts",
+			"0\t8\tsrc/another.ts",
 		].join("\n");
 
 		const commits = parseGitLogOutput(raw, "repo");
 		expect(commits[0].insertions).toBe(0);
-		expect(commits[0].deletions).toBe(15);
+		expect(commits[0].deletions).toBe(23); // 15 + 8
+		expect(commits[0].filesChanged).toBe(2);
 	});
 
-	it("handles commits with no shortstat (merge commits)", () => {
+	it("handles merge commits with no numstat lines", () => {
 		const raw = [
-			"ccc3333|Merge branch 'main' into feature|2026-02-20T11:00:00+00:00",
+			"ccc3333||Merge branch 'main' into feature|2026-02-20T11:00:00+00:00",
 			"",
-			"ddd4444|feat: Real commit|2026-02-20T12:00:00+00:00",
-			" 1 file changed, 5 insertions(+)",
+			"",
+			"ddd4444||feat: Real commit|2026-02-20T12:00:00+00:00",
+			"",
+			"5\t0\tsrc/feature.ts",
 		].join("\n");
 
 		const commits = parseGitLogOutput(raw, "repo");
@@ -77,8 +104,9 @@ describe("parseGitLogOutput", () => {
 	it("scrubs secrets from commit messages", () => {
 		const secret = "sk_test_abc123def456ghi789abcde";
 		const raw = [
-			`eee5555|fix: Update API key ${secret}|2026-02-20T10:00:00+00:00`,
-			" 1 file changed, 1 insertion(+)",
+			`eee5555||fix: Update API key ${secret}|2026-02-20T10:00:00+00:00`,
+			"",
+			"1\t1\tsrc/config.ts",
 		].join("\n");
 
 		const commits = parseGitLogOutput(raw, "repo");
@@ -88,13 +116,52 @@ describe("parseGitLogOutput", () => {
 
 	it("uses directory name as repo, not full path", () => {
 		const raw = [
-			"fff6666|feat: Something|2026-02-20T10:00:00+00:00",
-			" 1 file changed, 1 insertion(+)",
+			"fff6666||feat: Something|2026-02-20T10:00:00+00:00",
+			"",
+			"1\t0\tsrc/thing.ts",
 		].join("\n");
 
 		const commits = parseGitLogOutput(raw, "my-project");
 		expect(commits[0].repo).toBe("my-project");
 		expect(commits[0].repo).not.toContain("/");
+	});
+
+	it("handles binary files (numstat shows - for counts)", () => {
+		const raw = [
+			"ggg7777||chore: Add image|2026-02-20T10:00:00+00:00",
+			"",
+			"-\t-\tassets/logo.png",
+			"5\t2\tsrc/component.ts",
+		].join("\n");
+
+		const commits = parseGitLogOutput(raw, "repo");
+		// Binary files don't contribute to insertions/deletions counts
+		expect(commits[0].filesChanged).toBe(2); // both files counted
+		expect(commits[0].insertions).toBe(5);   // only from ts file
+		expect(commits[0].deletions).toBe(2);    // only from ts file
+	});
+
+	it("handles subject lines with | characters", () => {
+		const raw = [
+			"hhh8888||feat(render): add section A | section B|2026-02-20T10:00:00+00:00",
+			"",
+			"3\t0\tsrc/render.ts",
+		].join("\n");
+
+		const commits = parseGitLogOutput(raw, "repo");
+		expect(commits[0].message).toContain("section A | section B");
+	});
+
+	it("handles refs/decorator field", () => {
+		const raw = [
+			"iii9999|HEAD -> main, origin/main|fix: patch|2026-02-20T10:00:00+00:00",
+			"",
+			"1\t0\tsrc/patch.ts",
+		].join("\n");
+
+		const commits = parseGitLogOutput(raw, "repo");
+		expect(commits[0].hash).toBe("iii9999");
+		expect(commits[0].message).toBe("fix: patch");
 	});
 });
 
@@ -124,5 +191,4 @@ describe("readGitHistory", () => {
 		const result = readGitHistory(settings, new Date());
 		expect(result).toEqual([]);
 	});
-
 });

--- a/tests/unit/summarize/summarize.test.ts
+++ b/tests/unit/summarize/summarize.test.ts
@@ -135,6 +135,8 @@ describe("buildDeidentifiedPrompt", () => {
 			{ hour: 10, count: 8 },
 			{ hour: 14, count: 6 },
 		],
+		commitWorkUnits: [],
+		claudeTaskSessions: [],
 	};
 
 	it("includes aggregated activity distribution", () => {
@@ -262,6 +264,8 @@ function makeMockPatterns(): PatternAnalysis {
 		activityConcentrationScore: 0,
 		topActivityTypes: [],
 		peakHours: [],
+		commitWorkUnits: [],
+		claudeTaskSessions: [],
 	};
 }
 


### PR DESCRIPTION
## Summary

- **Commit work units** (`src/analyze/commits.ts`): Groups commits by 90-minute session gap into `CommitWorkUnit` entries with parsed conventional commit fields (`type`, `scope`, `breaking`) and `CommitWorkMode` classification (feat / fix / docs / chore / refactor)
- **Claude task sessions** (`src/analyze/task-sessions.ts`): Groups Claude Code JSONL sessions by `conversationFile` boundary into `ClaudeTaskSession` with turn count and extracted task title; detects `SearchMission` chains (query similarity within 10-min window); stubs `fuseCrossSourceSessions()` (returns `[]`) for phased delivery
- **New types** in `src/types.ts`: `ClaudeTaskType`, `CommitWorkMode`, `ParsedCommit`, `CommitWorkUnit`, `ClaudeTaskSession`, `SearchMission`, `UnifiedTaskSession`, `ArticleCluster`; added `filePaths?: string[]` to `GitCommit`; added `isConversationOpener`, `conversationFile`, `conversationTurnCount` to `ClaudeSession`
- **`--numstat` git log**: Upgraded from `--shortstat` to `--numstat` for per-file path capture
- **Knowledge sections**: "Today I Worked On" and "Today I Asked Claude About" rendered from new data
- **`GENERATED_HEADINGS`** updated with new semantic section names
- **ESLint / named capturing group fixes**: Rewrote `(?<name>...)` regex to positional for ES6 target compatibility

## Note

`fuseCrossSourceSessions()` is intentionally stubbed (returns `[]`). "Task Sessions" section is not yet rendered. This is a phased delivery — cross-source fusion is the next phase.

## Test plan

- [x] 924 unit tests passing, 45 skipped, 0 failed
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- New test files: `tests/unit/analyze/commits.test.ts` (32 tests), `tests/unit/analyze/task-sessions.test.ts` (27 tests)