### PR TITLE
test: add unit tests for ETL quality filters

### DIFF
--- a/tests/unit/etl/quality-filter.test.ts
+++ b/tests/unit/etl/quality-filter.test.ts
@@ -40,7 +40,7 @@ describe("hasConsecutiveDigitSegments", () => {
 	});
 
 	it("accepts domains with a single digit segment", () => {
-		expect(hasConsecutiveDigitSegments("site123.com")).toBe(false);
+		expect(hasConsecutiveDigitSegments("123.example.com")).toBe(false);
 	});
 
 	it("rejects domains with 3 consecutive digit segments", () => {
@@ -79,11 +79,11 @@ describe("hasSuspiciousTld", () => {
 });
 
 describe("isLowValueCcTld", () => {
-	it("rejects ccTLD domains ranked below threshold", () => {
+	it("rejects ccTLD domains with rank exceeding the threshold (less popular)", () => {
 		expect(isLowValueCcTld("obscure-site.de", 25_000)).toBe(true);
 	});
 
-	it("accepts ccTLD domains ranked above threshold", () => {
+	it("accepts ccTLD domains with rank below the threshold (more popular)", () => {
 		expect(isLowValueCcTld("popular-site.de", 5_000)).toBe(false);
 	});
 


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for all quality filter functions in `scripts/etl/lib/quality-filter.ts`.

## Tests Added (38 total)

- **`hasExcessiveHyphens`** — boundary cases around the >3 hyphens threshold
- **`hasConsecutiveDigitSegments`** — consecutive vs non-consecutive digit segments
- **`hasSuspiciousTld`** — known spam TLDs (.tk, .ml, .top, .click) vs safe ones
- **`isLowValueCcTld`** — rank threshold logic, generic-ish TLD exceptions (.io, .ai, .co), custom thresholds
- **`isSubdomainOfMajorPlatform`** — subdomain rejection, root domain acceptance, deep subdomains, CDN domains
- **`checkQuality`** — integration tests verifying the full pipeline and rejection priority order

All existing tests continue to pass (850 total).

Closes #80